### PR TITLE
pps: remove input_file_id from get_logs signature

### DIFF
--- a/src/python_pachyderm/pps_client.py
+++ b/src/python_pachyderm/pps_client.py
@@ -83,14 +83,14 @@ class PpsClient(object):
     def delete_all(self):
         self.stub.DeleteAll(google_dot_protobuf_dot_empty__pb2.Empty())
 
-    def get_logs(self, pipeline_name=None, job_id=None, data_filters=tuple(), input_file_id='', master=False):
+    def get_logs(self, pipeline_name=None, job_id=None, data_filters=tuple(), master=False):
         pipeline = Pipeline(name=pipeline_name) if pipeline_name else None
         job = Job(id=job_id) if job_id else None
         if pipeline is None and job is None:
             raise ValueError("One of 'pipeline_name' or 'job_id' must be specified")
         return list(self.stub.GetLogs(
             GetLogsRequest(pipeline=pipeline, job=job, data_filters=data_filters,
-                           input_file_id=input_file_id, master=master)))
+                           master=master)))
 
     def garbage_collect(self):
         return GarbageCollectResponse(self.stub.GarbageCollect(GarbageCollectRequest()))


### PR DESCRIPTION
in at least pach 1.7.3, there is no `input_file_id` field in the `GetLogsRequest`, so asking for logs raises an exception.

this fixes the issue on pach 1.7.3, but obviously removes support for some older versions (such as 1.6.5). i dont know what your strategy for dealing with versions is.