### PR TITLE
Fixup left over build references

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ include LICENSE
 include README.rst
 
 include VERSION
-include BUILD
+include BUILD_NUMBER
 
 include tox.ini .travis.yml
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ sync:
 
 release:
 	# Bump the version
-	expr $$(cat BUILD) + 1 > BUILD_NUMBER
+	expr $$(cat BUILD_NUMBER_NUMBER) + 1 > BUILD_NUMBER_NUMBER
 	python setup.py sdist
 	twine upload dist/*
 


### PR DESCRIPTION
Fixes some missed references of 'build' changed in this PR https://github.com/pachyderm/python-pachyderm/pull/25

relates to issues https://github.com/pachyderm/python-pachyderm/issues/24 and https://github.com/pachyderm/python-pachyderm/issues/20. 