### PR TITLE
fix(stop_pipeline): use keyword arg when creating Pipeline

### DIFF
--- a/src/python_pachyderm/pps_client.py
+++ b/src/python_pachyderm/pps_client.py
@@ -116,7 +116,7 @@ class PpsClient(object):
         self.stub.StartPipeline(req, metadata=self.metadata)
 
     def stop_pipeline(self, pipeline_name):
-        req = proto.StopPipelineRequest(pipeline=proto.Pipeline(pipeline_name))
+        req = proto.StopPipelineRequest(pipeline=proto.Pipeline(name=pipeline_name))
         self.stub.StopPipeline(req, metadata=self.metadata)
 
     def rerun_pipeline(self, pipeline_name, exclude=tuple(), include=tuple()):


### PR DESCRIPTION
- fixes TypeError when creating protobuf object with positional argument

fixes https://github.com/pachyderm/python-pachyderm/issues/60