### PR TITLE
Fix docs lists

### DIFF
--- a/src/python_pachyderm/pfs_client.py
+++ b/src/python_pachyderm/pfs_client.py
@@ -17,6 +17,7 @@ class PfsClient(object):
         Creates a client to connect to PFS.
 
         Params:
+
         * host: The pachd host. Default is 'localhost', which is used with
         `pachctl port-forward`.
         * port: The port to connect to. Default is 30650.
@@ -44,6 +45,7 @@ class PfsClient(object):
         database dumps etc.
 
         Params:
+
         * repo_name: Name of the repo.
         * description: An optional string describing the repo.
         * update: Whether to update if the repo already exists.
@@ -78,6 +80,7 @@ class PfsClient(object):
         Deletes a repo and reclaims the storage space it was using.
 
         Params:
+
         * repo_name: The name of the repo.
         * force: If set to true, the repo will be removed regardless of
         errors. This argument should be used with care.
@@ -90,6 +93,7 @@ class PfsClient(object):
         Deletes all repos.
 
         Params:
+
         * force: If set to true, the repo will be removed regardless of
         errors. This argument should be used with care.
         """
@@ -106,6 +110,7 @@ class PfsClient(object):
         returned.
 
         Params:
+
         * repo_name: A string specifying the name of the repo.
         * branch: A string specifying the branch name. This is a more
         convenient way to build linear chains of commits. When a commit is
@@ -138,6 +143,7 @@ class PfsClient(object):
         future attempts to write to it with PutFile will error.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * description: An optional string describing this commit.
         * tree_object_hashes: A list of zero or more strings specifying object
@@ -164,6 +170,7 @@ class PfsClient(object):
         A context manager for running operations within a commit.
 
         Params:
+
         * repo_name: A string specifying the name of the repo.
         * branch: A string specifying the branch name. This is a more
         convenient way to build linear chains of commits. When a commit is
@@ -188,6 +195,7 @@ class PfsClient(object):
         Inspects a commit. Returns a `CommitInfo` object.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * block_state: Causes inspect commit to block until the commit is in
         the desired commit state.
@@ -200,6 +208,7 @@ class PfsClient(object):
         Lists commits. Yields `CommitInfo` objects.
 
         Params:
+
         * repo_name: If only `repo_name` is given, all commits in the repo are
         returned.
         * to_commit: Optional. Only the ancestors of `to`, including `to`
@@ -222,6 +231,7 @@ class PfsClient(object):
         Deletes a commit.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         """
         req = proto.DeleteCommitRequest(commit=commit_from(commit))
@@ -243,6 +253,7 @@ class PfsClient(object):
         Yields `CommitInfo` objects.
 
         Params:
+
         * commits: A list of tuples, strings, or `Commit` objects representing
         the commits to flush.
         * repos: An optional list of strings specifying repo names. If
@@ -258,6 +269,7 @@ class PfsClient(object):
         Yields `CommitInfo` objects as commits occur.
 
         Params:
+
         * repo_name: A string specifying the name of the repo.
         * branch: A string specifying branch to subscribe to.
         * from_commit_id: An optional string specifying the commit ID. Only
@@ -303,6 +315,7 @@ class PfsClient(object):
         `BranchInfo` objects.
 
         Params:
+
         * repo_name: A string specifying the repo name.
         """
         req = proto.ListBranchRequest(repo=proto.Repo(name=repo_name))
@@ -316,6 +329,7 @@ class PfsClient(object):
         branches they happen to be on.
 
         Params:
+
         * repo_name: A string specifying the repo name.
         * branch_name: A string specifying the name of the branch to delete.
         * force: A bool specifying whether to force the branch deletion.
@@ -330,6 +344,7 @@ class PfsClient(object):
         Uploads a binary bytes array as file(s) in a certain path.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: A string specifying the path in the repo the file(s) will be
         written to.
@@ -409,6 +424,7 @@ class PfsClient(object):
         PFS function.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: A string specifying the path to the file.
         * url: A string specifying the url of the file to put.
@@ -431,6 +447,7 @@ class PfsClient(object):
         1.9.0) silently fail.
 
         Params:
+
         * source_commit: A tuple, string, or `Commit` object representing the
         commit for the source file.
         * source_path: A string specifying the path of the source file.
@@ -452,6 +469,7 @@ class PfsClient(object):
         Returns an iterator of the contents of a file at a specific commit.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: A string specifying the path of the file.
         * offset_bytes: An optional int. Specifies a number of bytes that
@@ -475,6 +493,7 @@ class PfsClient(object):
         Inspects a file. Returns a `FileInfo` object.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: A string specifying the path to the file.
         """
@@ -486,6 +505,7 @@ class PfsClient(object):
         Lists the files in a directory.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: The path to the directory.
         * history: An optional int that indicates to return jobs from
@@ -512,6 +532,7 @@ class PfsClient(object):
         `FileInfo` objects.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: The path to the directory.
         """
@@ -525,6 +546,7 @@ class PfsClient(object):
         Lists files that match a glob pattern. Yields `FileInfo` objects.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * pattern: A string representing a glob pattern.
         """
@@ -540,6 +562,7 @@ class PfsClient(object):
         will of course remain intact in the Commit's parent.
 
         Params:
+
         * commit: A tuple, string, or `Commit` object representing the commit.
         * path: The path to the file.
         """

--- a/src/python_pachyderm/pps_client.py
+++ b/src/python_pachyderm/pps_client.py
@@ -59,7 +59,8 @@ class PpsClient(object):
         representing an output commit to filter on.
         * history: An optional int that indicates to return jobs from
           historical versions of pipelines. Semantics are:
-            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 0: Return jobs from the current version of the pipeline or
+              pipelines.
             * 1: Return the above and jobs from the next most recent version
             * 2: etc.
             * -1: Return jobs from all historical versions.
@@ -232,7 +233,8 @@ class PpsClient(object):
         * pipeline_name: A string representing the pipeline name.
         * history: An optional int that indicates to return jobs from
         historical versions of pipelines. Semantics are:
-            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 0: Return jobs from the current version of the pipeline or
+              pipelines.
             * 1: Return the above and jobs from the next most recent version
             * 2: etc.
             * -1: Return jobs from all historical versions.
@@ -260,7 +262,8 @@ class PpsClient(object):
         * pipeline_name: A string representing the pipeline name.
         * history: An optional int that indicates to return jobs from
         historical versions of pipelines. Semantics are:
-            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 0: Return jobs from the current version of the pipeline or
+              pipelines.
             * 1: Return the above and jobs from the next most recent version
             * 2: etc.
             * -1: Return jobs from all historical versions.

--- a/src/python_pachyderm/pps_client.py
+++ b/src/python_pachyderm/pps_client.py
@@ -10,11 +10,13 @@ class PpsClient(object):
         """
         Creates a client to connect to PPS.
 
-        host: The pachd host. Default is 'localhost'.
-        port: The port to connect to. Default is 30650.
-        auth_token: The authentication token; used if authentication is
-        enabled on the cluster. Default to `None`.
-        root_certs:  The PEM-encoded root certificates as byte string.
+        Params:
+
+        * host: The pachd host. Default is 'localhost'.
+        * port: The port to connect to. Default is 30650.
+        * auth_token: The authentication token; used if authentication is
+        * enabled on the cluster. Default to `None`.
+        * root_certs:  The PEM-encoded root certificates as byte string.
         """
 
         address = get_address(host, port)
@@ -32,6 +34,7 @@ class PpsClient(object):
         Inspects a job with a given ID. Returns a `JobInfo`.
 
         Params:
+
         * job_id: The ID of the job to inspect.
         * block_state: If true, block until the job completes.
         * output_commit: An optional tuple, string, or `Commit` object
@@ -47,6 +50,7 @@ class PpsClient(object):
         Lists jobs. Yields `JobInfo` objects.
 
         Params:
+
         * pipeline_name: An optional string representing a pipeline name to
         filter on.
         * input_commit: An optional list of tuples, strings, or `Commit`
@@ -54,11 +58,11 @@ class PpsClient(object):
         * output_commit: An optional tuple, string, or `Commit` object
         representing an output commit to filter on.
         * history: An optional int that indicates to return jobs from
-        historical versions of pipelines. Semantics are:
-         0: Return jobs from the current version of the pipeline or pipelines.
-         1: Return the above and jobs from the next most recent version
-         2: etc.
-        -1: Return jobs from all historical versions.
+          historical versions of pipelines. Semantics are:
+            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 1: Return the above and jobs from the next most recent version
+            * 2: etc.
+            * -1: Return jobs from all historical versions.
         """
 
         pipeline = proto.Pipeline(name=pipeline_name) if pipeline_name is not None else None
@@ -81,6 +85,7 @@ class PpsClient(object):
         provenance have finished. Yields `JobInfo` objects.
 
         Params:
+
         * commits: A list of tuples, strings, or `Commit` objects representing
         the commits to flush.
         * pipeline_names: An optional list of strings specifying pipeline
@@ -97,6 +102,7 @@ class PpsClient(object):
         Deletes a job by its ID.
 
         Params:
+
         * job_id: The ID of the job to delete.
         """
 
@@ -108,6 +114,7 @@ class PpsClient(object):
         Stops a job by its ID.
 
         Params:
+
         * job_id: The ID of the job to stop.
         """
 
@@ -119,6 +126,7 @@ class PpsClient(object):
         Inspects a datum. Returns a `DatumInfo` object.
 
         Params:
+
         * job_id: The ID of the job.
         * datum_id: The ID of the datum.
         """
@@ -131,6 +139,7 @@ class PpsClient(object):
         Lists datums. Yields `ListDatumStreamResponse` objects.
 
         Params:
+
         * job_id: The ID of the job.
         * page_size: An optional int specifying the size of the page.
         * page: An optional int specifying the page number.
@@ -144,6 +153,7 @@ class PpsClient(object):
         Restarts a datum.
 
         Params:
+
         * job_id: The ID of the job.
         * data_filters: An optional iterable of strings.
         """
@@ -165,6 +175,7 @@ class PpsClient(object):
         http://docs.pachyderm.io/en/latest/reference/pipeline_spec.html
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         * transform: An optional `Transform` object.
         * parallelism_spec: An optional `ParallelismSpec` object.
@@ -217,13 +228,14 @@ class PpsClient(object):
         Inspects a pipeline. Returns a `PipelineInfo` object.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         * history: An optional int that indicates to return jobs from
         historical versions of pipelines. Semantics are:
-         0: Return jobs from the current version of the pipeline or pipelines.
-         1: Return the above and jobs from the next most recent version
-         2: etc.
-        -1: Return jobs from all historical versions.
+            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 1: Return the above and jobs from the next most recent version
+            * 2: etc.
+            * -1: Return jobs from all historical versions.
         """
 
         pipeline = proto.Pipeline(name=pipeline_name)
@@ -244,13 +256,14 @@ class PpsClient(object):
         Lists pipelines. Returns a `PipelineInfos` object.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         * history: An optional int that indicates to return jobs from
         historical versions of pipelines. Semantics are:
-         0: Return jobs from the current version of the pipeline or pipelines.
-         1: Return the above and jobs from the next most recent version
-         2: etc.
-        -1: Return jobs from all historical versions.
+            * 0: Return jobs from the current version of the pipeline or pipelines.
+            * 1: Return the above and jobs from the next most recent version
+            * 2: etc.
+            * -1: Return jobs from all historical versions.
         """
         req = proto.ListPipelineRequest(history=history)
         return self.stub.ListPipeline(req, metadata=self.metadata)
@@ -260,6 +273,7 @@ class PpsClient(object):
         Deletes a pipeline.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         * force: Whether to force delete.
         """
@@ -272,6 +286,7 @@ class PpsClient(object):
         Deletes all pipelines.
 
         Params:
+
         * force: Whether to force delete.
         """
 
@@ -283,6 +298,7 @@ class PpsClient(object):
         Starts a pipeline.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         """
 
@@ -294,6 +310,7 @@ class PpsClient(object):
         Stops a pipeline.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         """
         req = proto.StopPipelineRequest(pipeline=proto.Pipeline(name=pipeline_name))
@@ -304,6 +321,7 @@ class PpsClient(object):
         Runs a pipeline.
 
         Params:
+
         * pipeline_name: A string representing the pipeline name.
         * provenance: An optional iterable of `CommitProvenance` objects
         representing the pipeline execution provenance.
@@ -327,6 +345,7 @@ class PpsClient(object):
         Gets logs for a pipeline. Yields `LogMessage` objects.
 
         Params:
+
         * pipeline_name: A string representing a pipeline to get
         logs of.
         * data_filters: An optional iterable of strings specifying the names
@@ -356,6 +375,7 @@ class PpsClient(object):
         Gets logs for a job. Yields `LogMessage` objects.
 
         Params:
+
         * job_id: A string representing a job to get logs of.
         * data_filters: An optional iterable of strings specifying the names
         of input files from which we want processing logs. This may contain


### PR DESCRIPTION
Reading the `pdoc` rendered docs is a little hard because the params list don't render correctly. This should fix that.