### PR TITLE
Bring back the `PACH_PYTHON_AUTH_TOKEN` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1
+
+- Re-introduced `PACH_PYTHON_AUTH_TOKEN`, as we need it for JupyterHub integration (PR #161)
+
 ## 2.4.0
 
 - Synced with pachyderm core v1.9.8 (PR #159)

--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -45,6 +45,9 @@ class Client(
         host = host or "localhost"
         port = port or 30650
 
+        if auth_token is None:
+            auth_token = os.environ.get("PACH_PYTHON_AUTH_TOKEN")
+
         if tls is None:
             tls = root_certs is not None
         if tls and root_certs is None:

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "pachyderm": "1.9.8",
-    "python-pachyderm": "2.4.0"
+    "python-pachyderm": "2.4.1"
 }


### PR DESCRIPTION
This was recently removed in v2.3.0, but it turns out that we'll need this env var for JupyterHub integration.