### PR TITLE
Added ability to atomically put or delete many PFS files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ docs:
 	# 1) pdoc has totally different flows for virtualenv-based vs system-based
 	# packages, and will generate different docs.
 	# 2) pdoc will frequently ignore virtualenv anyways.
-	rm -rf build dist
-	python3 setup.py clean build install
+	sudo rm -rf build dist
+	python3 setup.py clean build
+	sudo python3 setup.py install
 	pdoc --html --html-dir docs python_pachyderm
 
 docker-build-proto:

--- a/docs/python_pachyderm.m.html
+++ b/docs/python_pachyderm.m.html
@@ -1260,6 +1260,7 @@ table {
     <li class="mono"><a href="#python_pachyderm.Client.modify_members">modify_members</a></li>
     <li class="mono"><a href="#python_pachyderm.Client.profile_cpu">profile_cpu</a></li>
     <li class="mono"><a href="#python_pachyderm.Client.put_file_bytes">put_file_bytes</a></li>
+    <li class="mono"><a href="#python_pachyderm.Client.put_file_client">put_file_client</a></li>
     <li class="mono"><a href="#python_pachyderm.Client.put_file_url">put_file_url</a></li>
     <li class="mono"><a href="#python_pachyderm.Client.restart_datum">restart_datum</a></li>
     <li class="mono"><a href="#python_pachyderm.Client.restore">restore</a></li>
@@ -1978,6 +1979,20 @@ table {
         
         </li>
         <li class="mono">
+        <span class="class_name"><a href="#python_pachyderm.PutFileClient">PutFileClient</a></span>
+        
+          
+  <ul>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.__init__">__init__</a></li>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.delete_file">delete_file</a></li>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.put_file_from_bytes">put_file_from_bytes</a></li>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.put_file_from_fileobj">put_file_from_fileobj</a></li>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.put_file_from_filepath">put_file_from_filepath</a></li>
+    <li class="mono"><a href="#python_pachyderm.PutFileClient.put_file_from_url">put_file_from_url</a></li>
+  </ul>
+
+        </li>
+        <li class="mono">
         <span class="class_name"><a href="#python_pachyderm.PutFileRecord">PutFileRecord</a></span>
         
         </li>
@@ -2428,7 +2443,8 @@ pipeline. Defaults to <code>python</code>.</li>
 <li><code>source_path</code>: The directory to recursively insert content from.</li>
 <li><code>commit</code>: The <code>Commit</code> object to use for inserting files.</li>
 <li><code>dest_path</code>: The destination path in PFS.</li>
-<li><code>kwargs</code>: Keyword arguments to forward to <code>put_file_bytes</code>.</li>
+<li><code>kwargs</code>: Keyword arguments to forward. See
+<code>PutFileClient.put_file_from_fileobj</code> for details.</li>
 </ul>
 </div>
   <div class="source_cont">
@@ -6249,7 +6265,8 @@ profiler.</li>
 
     
   
-    <div class="desc"><p>Uploads a binary bytes array as file(s) in a certain path.</p>
+    <div class="desc"><p>Uploads a PFS file from a file-like object, bytestring, or iterator
+of bytestrings.</p>
 
 <p>Params:</p>
 
@@ -6268,13 +6285,31 @@ evenly, but will never be higher, unless the value is 0.</li>
 <li><code>target_file_bytes</code>: An optional int. Specifies the target number of
 bytes in each written file, files may have more or fewer bytes than
 the target.</li>
-<li><code>overwrite_index</code>: An optional <code>OverwriteIndex</code> object. This is the
-object index where the write starts from.  All existing objects
-starting from the index are deleted.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
 <li><code>header_records: An optional int for splitting data when</code>delimiter<code>
 is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
 converted to a header and applied to all file shards.</li>
 </ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.Client.put_file_client">
+    <p>def <span class="ident">put_file_client</span>(</p><p>*args, **kwds)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>A context manager that gives a <code>PutFileClient</code>. When the context
+manager exits, any operations enqueued from the <code>PutFileClient</code> are
+executed in a single, atomic <code>PutFile</code> call.</p>
 </div>
   <div class="source_cont">
 </div>
@@ -6291,8 +6326,7 @@ converted to a header and applied to all file shards.</li>
     
   
     <div class="desc"><p>Puts a file using the content found at a URL. The URL is sent to the
-server which performs the request. Note that this is not a standard
-PFS function.</p>
+server which performs the request.</p>
 
 <p>Params:</p>
 
@@ -6311,9 +6345,9 @@ evenly, but will never be higher, unless the value is 0.</li>
 <li><code>target_file_bytes</code>: An optional int. Specifies the target number of
 bytes in each written file, files may have more or fewer bytes than
 the target.</li>
-<li><code>overwrite_index</code>: An optional <code>OverwriteIndex</code> object. This is the
-object index where the write starts from.  All existing objects
-starting from the index are deleted.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
 <li><code>header_records: An optional int for splitting data when</code>delimiter<code>
 is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
 converted to a header and applied to all file shards.</li>
@@ -18618,6 +18652,226 @@ with open("montage.png", "wb") as dest_file:
 </div>
 
             </div>
+      </div>
+      </div>
+      
+      <div class="item">
+      <p id="python_pachyderm.PutFileClient" class="name">class <span class="ident">PutFileClient</span></p>
+      
+  
+    <div class="desc"><p><code>PutFileClient</code> puts or deletes PFS files atomically.</p>
+</div>
+  <div class="source_cont">
+</div>
+
+
+      <div class="class">
+          <h3>Methods</h3>
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.__init__">
+    <p>def <span class="ident">__init__</span>(</p><p>self)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Initialize self.  See help(type(self)) for accurate signature.</p>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.delete_file">
+    <p>def <span class="ident">delete_file</span>(</p><p>self, commit, path)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Deletes a file.</p>
+
+<p>Params:</p>
+
+<ul>
+<li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
+commit.</li>
+<li><code>path</code>: The path to the file.</li>
+</ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.put_file_from_bytes">
+    <p>def <span class="ident">put_file_from_bytes</span>(</p><p>self, commit, path, value, delimiter=None, target_file_datums=None, target_file_bytes=None, overwrite_index=None, header_records=None)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Uploads a PFS file from a bytestring.</p>
+
+<p>Params:</p>
+
+<ul>
+<li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
+commit.</li>
+<li><code>path</code>: A string specifying the path in the repo the file(s) will be
+written to.</li>
+<li><code>value</code>: The file contents as a bytestring.</li>
+<li><code>delimiter</code>: Optional. causes data to be broken up into separate
+files with <code>path</code> as a prefix.</li>
+<li><code>target_file_datums</code>: An optional int. Specifies the target number of
+datums in each written file. It may be lower if data does not split
+evenly, but will never be higher, unless the value is 0.</li>
+<li><code>target_file_bytes</code>: An optional int. Specifies the target number of
+bytes in each written file, files may have more or fewer bytes than
+the target.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
+<li><code>header_records: An optional int for splitting data when</code>delimiter<code>
+is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
+converted to a header and applied to all file shards.</li>
+</ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.put_file_from_fileobj">
+    <p>def <span class="ident">put_file_from_fileobj</span>(</p><p>self, commit, path, value, delimiter=None, target_file_datums=None, target_file_bytes=None, overwrite_index=None, header_records=None)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Uploads a PFS file from a file-like object.</p>
+
+<p>Params:</p>
+
+<ul>
+<li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
+commit.</li>
+<li><code>path</code>: A string specifying the path in the repo the file(s) will be
+written to.</li>
+<li><code>value</code>: The file-like object.</li>
+<li><code>delimiter</code>: Optional. causes data to be broken up into separate
+files with <code>path</code> as a prefix.</li>
+<li><code>target_file_datums</code>: An optional int. Specifies the target number of
+datums in each written file. It may be lower if data does not split
+evenly, but will never be higher, unless the value is 0.</li>
+<li><code>target_file_bytes</code>: An optional int. Specifies the target number of
+bytes in each written file, files may have more or fewer bytes than
+the target.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
+<li><code>header_records: An optional int for splitting data when</code>delimiter<code>
+is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
+converted to a header and applied to all file shards.</li>
+</ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.put_file_from_filepath">
+    <p>def <span class="ident">put_file_from_filepath</span>(</p><p>self, commit, pfs_path, local_path, delimiter=None, target_file_datums=None, target_file_bytes=None, overwrite_index=None, header_records=None)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Uploads a PFS file from a local path at a specified path. This will
+lazily open files, which will prevent too many files from being
+opened, or too much memory being consumed, when atomically putting
+many files.</p>
+
+<p>Params:</p>
+
+<ul>
+<li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
+commit.</li>
+<li><code>pfs_path</code>: A string specifying the path in the repo the file(s)
+will be written to.</li>
+<li><code>local_path</code>: A string specifying the local file path.</li>
+<li><code>delimiter</code>: Optional. causes data to be broken up into separate
+files with <code>path</code> as a prefix.</li>
+<li><code>target_file_datums</code>: An optional int. Specifies the target number of
+datums in each written file. It may be lower if data does not split
+evenly, but will never be higher, unless the value is 0.</li>
+<li><code>target_file_bytes</code>: An optional int. Specifies the target number of
+bytes in each written file, files may have more or fewer bytes than
+the target.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
+<li><code>header_records: An optional int for splitting data when</code>delimiter<code>
+is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
+converted to a header and applied to all file shards.</li>
+</ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
+            
+  <div class="item">
+    <div class="name def" id="python_pachyderm.PutFileClient.put_file_from_url">
+    <p>def <span class="ident">put_file_from_url</span>(</p><p>self, commit, path, url, delimiter=None, recursive=None, target_file_datums=None, target_file_bytes=None, overwrite_index=None, header_records=None)</p>
+    </div>
+    
+
+    
+  
+    <div class="desc"><p>Puts a file using the content found at a URL. The URL is sent to the
+server which performs the request.</p>
+
+<p>Params:</p>
+
+<ul>
+<li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
+commit.</li>
+<li><code>path</code>: A string specifying the path to the file.</li>
+<li><code>url</code>: A string specifying the url of the file to put.</li>
+<li><code>delimiter</code>: Optional. causes data to be broken up into separate
+files with <code>path</code> as a prefix.</li>
+<li><code>recursive</code>: allow for recursive scraping of some types URLs, for
+example on s3:// URLs.</li>
+<li><code>target_file_datums</code>: An optional int. Specifies the target number of
+datums in each written file. It may be lower if data does not split
+evenly, but will never be higher, unless the value is 0.</li>
+<li><code>target_file_bytes</code>: An optional int. Specifies the target number of
+bytes in each written file, files may have more or fewer bytes than
+the target.</li>
+<li><code>overwrite_index</code>: An optional int. This is the object index where
+the write starts from.  All existing objects starting from the index
+are deleted.</li>
+<li><code>header_records: An optional int for splitting data when</code>delimiter<code>
+is not</code>NONE<code>(or</code>SQL`). It specifies the number of records that are
+converted to a header and applied to all file shards.</li>
+</ul>
+</div>
+  <div class="source_cont">
+</div>
+
+  </div>
+  
       </div>
       </div>
       

--- a/docs/python_pachyderm.m.html
+++ b/docs/python_pachyderm.m.html
@@ -6277,8 +6277,10 @@ commit.</li>
 written to.</li>
 <li><code>value</code>: The file contents as bytes, represented as a file-like
 object, bytestring, or iterator of bytestrings.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of
 datums in each written file. It may be lower if data does not split
 evenly, but will never be higher, unless the value is 0.</li>
@@ -6335,8 +6337,10 @@ server which performs the request.</p>
 commit.</li>
 <li><code>path</code>: A string specifying the path to the file.</li>
 <li><code>url</code>: A string specifying the url of the file to put.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>recursive</code>: allow for recursive scraping of some types URLs, for
 example on s3:// URLs.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of
@@ -18726,8 +18730,10 @@ commit.</li>
 <li><code>path</code>: A string specifying the path in the repo the file(s) will be
 written to.</li>
 <li><code>value</code>: The file contents as a bytestring.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of
 datums in each written file. It may be lower if data does not split
 evenly, but will never be higher, unless the value is 0.</li>
@@ -18766,8 +18772,10 @@ commit.</li>
 <li><code>path</code>: A string specifying the path in the repo the file(s) will be
 written to.</li>
 <li><code>value</code>: The file-like object.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of
 datums in each written file. It may be lower if data does not split
 evenly, but will never be higher, unless the value is 0.</li>
@@ -18809,8 +18817,10 @@ commit.</li>
 <li><code>pfs_path</code>: A string specifying the path in the repo the file(s)
 will be written to.</li>
 <li><code>local_path</code>: A string specifying the local file path.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of
 datums in each written file. It may be lower if data does not split
 evenly, but will never be higher, unless the value is 0.</li>
@@ -18849,8 +18859,10 @@ server which performs the request.</p>
 commit.</li>
 <li><code>path</code>: A string specifying the path to the file.</li>
 <li><code>url</code>: A string specifying the url of the file to put.</li>
-<li><code>delimiter</code>: Optional. causes data to be broken up into separate
-files with <code>path</code> as a prefix.</li>
+<li><code>delimiter</code>: An optional int. causes data to be broken up into
+separate files by the delimiter. e.g. if you used
+<code>Delimiter.CSV.value</code>, a separate PFS file will be created for each
+row in the input CSV file, rather than one large CSV file.</li>
 <li><code>recursive</code>: allow for recursive scraping of some types URLs, for
 example on s3:// URLs.</li>
 <li><code>target_file_datums</code>: An optional int. Specifies the target number of

--- a/etc/proto_lint/proto_lint.py
+++ b/etc/proto_lint/proto_lint.py
@@ -227,13 +227,11 @@ RENAMED_ARGS = {
         ("file", ("commit", "path")),
         ("url", None),
         ("recursive", None),
-        # TODO: would be good to support this at some point
         ("delete", None),
     ],
     "put_file_url": [
         ("file", ("commit", "path")),
         ("value", None),
-        # TODO: would be good to support this at some point
         ("delete", None),
     ],
     "start_commit": [

--- a/src/python_pachyderm/__init__.py
+++ b/src/python_pachyderm/__init__.py
@@ -3,7 +3,7 @@ import importlib as _importlib
 import enum as _enum
 from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper as _EnumTypeWrapper
 
-from .mixin.pfs import PFSFile
+from .mixin.pfs import PFSFile, PutFileClient
 from .client import Client
 from .spout import SpoutManager
 from .util import put_files, create_python_pipeline, parse_json_pipeline_spec, parse_dict_pipeline_spec
@@ -16,6 +16,7 @@ __all__ = [
     "put_files",
     "create_python_pipeline",
     "PFSFile",
+    "PutFileClient",
     "parse_json_pipeline_spec",
     "parse_dict_pipeline_spec",
 ]

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -382,9 +382,9 @@ class PFSMixin:
 
     @contextmanager
     def put_file_client(self):
-        client = PutFileClient()
-        yield client
-        self._req(Service.PFS, "PutFile", req=client._reqs())
+        pfc = PutFileClient()
+        yield pfc
+        self._req(Service.PFS, "PutFile", req=pfc._reqs())
 
     def put_file_bytes(self, commit, path, value, delimiter=None, target_file_datums=None,
                        target_file_bytes=None, overwrite_index=None, header_records=None):
@@ -408,9 +408,9 @@ class PFSMixin:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -420,9 +420,9 @@ class PFSMixin:
                 "'put_file_bytes' with an iterable 'value' is deprecated, use file-like objects or bytestrings instead",
                 DeprecationWarning,
             )
-            pfs_file = pfs_proto.File(commit=commit_from(commit), path=path)
             reqs = _put_file_from_iterable_reqs(
-                pfs_file, value,
+                value,
+                file=pfs_proto.File(commit=commit_from(commit), path=path),
                 delimiter=delimiter,
                 target_file_datums=target_file_datums,
                 target_file_bytes=target_file_bytes,
@@ -442,7 +442,7 @@ class PFSMixin:
                     header_records=header_records,
                 )
             else:
-                return pfc.put_file_from_bytestring(
+                return pfc.put_file_from_bytes(
                     commit, path, value,
                     delimiter=delimiter,
                     target_file_datums=target_file_datums,
@@ -473,9 +473,9 @@ class PFSMixin:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -484,7 +484,6 @@ class PFSMixin:
         with self.put_file_client() as pfc:
             pfc.put_file_from_url(
                 commit, path, url,
-                url=url,
                 delimiter=delimiter,
                 recursive=recursive,
                 target_file_datums=target_file_datums,
@@ -690,9 +689,9 @@ class PutFileClient:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -702,7 +701,7 @@ class PutFileClient:
             delimiter=delimiter,
             target_file_datums=target_file_datums,
             target_file_bytes=target_file_bytes,
-            overwrite_index=overwrite_index,
+            overwrite_index=pfs_proto.OverwriteIndex(index=overwrite_index) if overwrite_index is not None else None,
             header_records=header_records,
         ))
 
@@ -726,9 +725,9 @@ class PutFileClient:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -738,7 +737,7 @@ class PutFileClient:
             delimiter=delimiter,
             target_file_datums=target_file_datums,
             target_file_bytes=target_file_bytes,
-            overwrite_index=overwrite_index,
+            overwrite_index=pfs_proto.OverwriteIndex(index=overwrite_index) if overwrite_index is not None else None,
             header_records=header_records,
         ))
 
@@ -762,9 +761,9 @@ class PutFileClient:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -800,9 +799,9 @@ class PutFileClient:
         * `target_file_bytes`: An optional int. Specifies the target number of
         bytes in each written file, files may have more or fewer bytes than
         the target.
-        * `overwrite_index`: An optional `OverwriteIndex` object. This is the
-        object index where the write starts from.  All existing objects
-        starting from the index are deleted.
+        * `overwrite_index`: An optional int. This is the object index where
+        the write starts from.  All existing objects starting from the index
+        are deleted.
         * `header_records: An optional int for splitting data when `delimiter`
         is not `NONE` (or `SQL`). It specifies the number of records that are
         converted to a header and applied to all file shards.
@@ -814,7 +813,7 @@ class PutFileClient:
             recursive=recursive,
             target_file_datums=target_file_datums,
             target_file_bytes=target_file_bytes,
-            overwrite_index=overwrite_index,
+            overwrite_index=pfs_proto.OverwriteIndex(index=overwrite_index) if overwrite_index is not None else None,
             header_records=header_records,
         ))
 
@@ -847,7 +846,7 @@ class _AtomicPutFilepathOp(_AtomicOp):
 
     def reqs(self):
         with open(self.local_path, "rb") as f:
-            yield from _put_file_from_fileobj_reqs(self.pfs_file, f, **self.kwargs)
+            yield from _put_file_from_fileobj_reqs(f, **self.kwargs)
 
 
 class _AtomicPutFileobjOp(_AtomicOp):
@@ -856,10 +855,10 @@ class _AtomicPutFileobjOp(_AtomicOp):
         self.value = value
 
     def reqs(self):
-        yield from _put_file_from_fileobj_reqs(self.pfs_file, self.value, **self.kwargs)
+        yield from _put_file_from_fileobj_reqs(self.value, **self.kwargs)
 
 
-def _put_file_from_fileobj_reqs(pfs_file, value, **kwargs):
+def _put_file_from_fileobj_reqs(value, **kwargs):
     for i in itertools.count():
         chunk = value.read(BUFFER_SIZE)
 
@@ -867,14 +866,14 @@ def _put_file_from_fileobj_reqs(pfs_file, value, **kwargs):
             return
 
         if i == 0:
-            yield pfs_proto.PutFileRequest(file=pfs_file, value=chunk, **kwargs)
+            yield pfs_proto.PutFileRequest(value=chunk, **kwargs)
         else:
             yield pfs_proto.PutFileRequest(value=chunk)
 
 
-def _put_file_from_iterable_reqs(pfs_file, value, **kwargs):
+def _put_file_from_iterable_reqs(value, **kwargs):
     for i, chunk in enumerate(value):
         if i == 0:
-            yield pfs_proto.PutFileRequest(file=pfs_file, value=chunk, **kwargs)
+            yield pfs_proto.PutFileRequest(value=chunk, **kwargs)
         else:
             yield pfs_proto.PutFileRequest(value=chunk)

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -384,7 +384,7 @@ class PFSMixin:
     def put_file_client(self):
         client = PutFileClient()
         yield client
-        return self._req(Service.PFS, "PutFile", req=client._reqs())
+        self._req(Service.PFS, "PutFile", req=client._reqs())
 
     def put_file_bytes(self, commit, path, value, delimiter=None, target_file_datums=None,
                        target_file_bytes=None, overwrite_index=None, header_records=None):

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -405,8 +405,10 @@ class PFSMixin:
         written to.
         * `value`: The file contents as bytes, represented as a file-like
         object, bytestring, or iterator of bytestrings.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `target_file_datums`: An optional int. Specifies the target number of
         datums in each written file. It may be lower if data does not split
         evenly, but will never be higher, unless the value is 0.
@@ -468,8 +470,10 @@ class PFSMixin:
         commit.
         * `path`: A string specifying the path to the file.
         * `url`: A string specifying the url of the file to put.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `recursive`: allow for recursive scraping of some types URLs, for
         example on s3:// URLs.
         * `target_file_datums`: An optional int. Specifies the target number of
@@ -686,8 +690,10 @@ class PutFileClient:
         * `pfs_path`: A string specifying the path in the repo the file(s)
         will be written to.
         * `local_path`: A string specifying the local file path.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `target_file_datums`: An optional int. Specifies the target number of
         datums in each written file. It may be lower if data does not split
         evenly, but will never be higher, unless the value is 0.
@@ -722,8 +728,10 @@ class PutFileClient:
         * `path`: A string specifying the path in the repo the file(s) will be
         written to.
         * `value`: The file-like object.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `target_file_datums`: An optional int. Specifies the target number of
         datums in each written file. It may be lower if data does not split
         evenly, but will never be higher, unless the value is 0.
@@ -758,8 +766,10 @@ class PutFileClient:
         * `path`: A string specifying the path in the repo the file(s) will be
         written to.
         * `value`: The file contents as a bytestring.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `target_file_datums`: An optional int. Specifies the target number of
         datums in each written file. It may be lower if data does not split
         evenly, but will never be higher, unless the value is 0.
@@ -794,8 +804,10 @@ class PutFileClient:
         commit.
         * `path`: A string specifying the path to the file.
         * `url`: A string specifying the url of the file to put.
-        * `delimiter`: Optional. causes data to be broken up into separate
-        files with `path` as a prefix.
+        * `delimiter`: An optional int. causes data to be broken up into
+        separate files by the delimiter. e.g. if you used
+        `Delimiter.CSV.value`, a separate PFS file will be created for each
+        row in the input CSV file, rather than one large CSV file.
         * `recursive`: allow for recursive scraping of some types URLs, for
         example on s3:// URLs.
         * `target_file_datums`: An optional int. Specifies the target number of

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -267,14 +267,16 @@ def test_put_file_atomic():
     assert files[2].file.path == '/file3.dat'
     assert files[3].file.path == '/index.html'
 
-    with client.put_file_client() as pfc:
-        pfc.delete_file(commit, "/file1.dat")
-        pfc.delete_file(commit, "/file2.dat")
-        pfc.delete_file(commit, "/file3.dat")
+    # atomic deletes are only supported in 1.11.0 onwards
+    if util.test_pachyderm_version() >= (1, 11, 0):
+        with client.put_file_client() as pfc:
+            pfc.delete_file(commit, "/file1.dat")
+            pfc.delete_file(commit, "/file2.dat")
+            pfc.delete_file(commit, "/file3.dat")
 
-    files = list(client.list_file(commit, '.'))
-    assert len(files) == 1
-    assert files[0].file.path == '/index.html'
+        files = list(client.list_file(commit, '.'))
+        assert len(files) == 1
+        assert files[0].file.path == '/index.html'
 
 def test_copy_file():
     client, repo_name = sandbox("copy_file")


### PR DESCRIPTION
Added a `PutFileClient`, akin to the [go variant.](https://godoc.org/github.com/pachyderm/pachyderm/src/client#PutFileClient) This allows us to support putting and deleting multiple files atomically, without acting on an open commit. Existing functions have been updated to use `PutFileClient` where possible.