### PR TITLE
Better dynamic enum generation, with support for docs and introspection

### DIFF
--- a/docs/python_pachyderm.m.html
+++ b/docs/python_pachyderm.m.html
@@ -6822,10 +6822,59 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.ClusterRole.FS" class="name">var <span class="ident">FS</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.ClusterRole.SUPER" class="name">var <span class="ident">SUPER</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.ClusterRole.UNDEFINED" class="name">var <span class="ident">UNDEFINED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.ClusterRole.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.ClusterRole.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -7392,10 +7441,59 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.CommitState.FINISHED" class="name">var <span class="ident">FINISHED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.CommitState.READY" class="name">var <span class="ident">READY</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.CommitState.STARTED" class="name">var <span class="ident">STARTED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.CommitState.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.CommitState.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -8572,10 +8670,79 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.FAILED" class="name">var <span class="ident">FAILED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.RECOVERED" class="name">var <span class="ident">RECOVERED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.SKIPPED" class="name">var <span class="ident">SKIPPED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.STARTING" class="name">var <span class="ident">STARTING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.SUCCESS" class="name">var <span class="ident">SUCCESS</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.DatumState.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -9412,10 +9579,79 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.CSV" class="name">var <span class="ident">CSV</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.JSON" class="name">var <span class="ident">JSON</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.LINE" class="name">var <span class="ident">LINE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.NONE" class="name">var <span class="ident">NONE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.SQL" class="name">var <span class="ident">SQL</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Delimiter.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -10930,10 +11166,59 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.FileType.DIR" class="name">var <span class="ident">DIR</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.FileType.FILE" class="name">var <span class="ident">FILE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.FileType.RESERVED" class="name">var <span class="ident">RESERVED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.FileType.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.FileType.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -15060,10 +15345,99 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_EGRESSING" class="name">var <span class="ident">JOB_EGRESSING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_FAILURE" class="name">var <span class="ident">JOB_FAILURE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_KILLED" class="name">var <span class="ident">JOB_KILLED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_MERGING" class="name">var <span class="ident">JOB_MERGING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_RUNNING" class="name">var <span class="ident">JOB_RUNNING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_STARTING" class="name">var <span class="ident">JOB_STARTING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.JOB_SUCCESS" class="name">var <span class="ident">JOB_SUCCESS</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.JobState.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -17490,10 +17864,59 @@ commit.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.OriginKind.AUTO" class="name">var <span class="ident">AUTO</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.OriginKind.FSCK" class="name">var <span class="ident">FSCK</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.OriginKind.USER" class="name">var <span class="ident">USER</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.OriginKind.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.OriginKind.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -18464,10 +18887,99 @@ with open("montage.png", "wb") as dest_file:
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_CRASHING" class="name">var <span class="ident">PIPELINE_CRASHING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_FAILURE" class="name">var <span class="ident">PIPELINE_FAILURE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_PAUSED" class="name">var <span class="ident">PIPELINE_PAUSED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_RESTARTING" class="name">var <span class="ident">PIPELINE_RESTARTING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_RUNNING" class="name">var <span class="ident">PIPELINE_RUNNING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_STANDBY" class="name">var <span class="ident">PIPELINE_STANDBY</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.PIPELINE_STARTING" class="name">var <span class="ident">PIPELINE_STARTING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.PipelineState.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -19854,10 +20366,69 @@ with open("montage.png", "wb") as dest_file:
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.Scope.NONE" class="name">var <span class="ident">NONE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Scope.OWNER" class="name">var <span class="ident">OWNER</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Scope.READER" class="name">var <span class="ident">READER</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Scope.WRITER" class="name">var <span class="ident">WRITER</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Scope.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.Scope.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -21171,10 +21742,59 @@ tested outside of a real Pachyderm pipeline.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.State.ACTIVE" class="name">var <span class="ident">ACTIVE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.State.EXPIRED" class="name">var <span class="ident">EXPIRED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.State.NONE" class="name">var <span class="ident">NONE</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.State.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.State.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       
@@ -23084,10 +23704,59 @@ tested outside of a real Pachyderm pipeline.</li>
       <div class="class">
           <h3>Ancestors (in MRO)</h3>
           <ul class="class_list">
-          <li><a href="/enum.IntEnum.ext">enum.IntEnum</a></li>
-          <li><a href="/builtins.int.ext">builtins.int</a></li>
           <li><a href="/enum.Enum.ext">enum.Enum</a></li>
           </ul>
+          <h3>Class variables</h3>
+            <div class="item">
+            <p id="python_pachyderm.WorkerState.POD_FAILED" class="name">var <span class="ident">POD_FAILED</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.WorkerState.POD_RUNNING" class="name">var <span class="ident">POD_RUNNING</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.WorkerState.POD_SUCCESS" class="name">var <span class="ident">POD_SUCCESS</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.WorkerState.name" class="name">var <span class="ident">name</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
+            <div class="item">
+            <p id="python_pachyderm.WorkerState.value" class="name">var <span class="ident">value</span></p>
+            
+
+            
+  
+  <div class="source_cont">
+</div>
+
+            </div>
       </div>
       </div>
       

--- a/docs/python_pachyderm.m.html
+++ b/docs/python_pachyderm.m.html
@@ -4393,8 +4393,8 @@ the caller has at least <code>scope</code>-level access to <code>repo</code>.</p
 <ul>
 <li><code>repo</code>: A string specifying the repo name that the caller wants
 access to.</li>
-<li><code>scope</code>: A <code>Scope</code> object specifying the access level that the
-caller needs to perform an action.</li>
+<li><code>scope</code>: An int specifying the access level that the caller needs to
+perform an action. See the <code>Scope</code> enum for variants.</li>
 </ul>
 </div>
   <div class="source_cont">
@@ -5739,9 +5739,9 @@ commit.</li>
 
 <ul>
 <li><code>commit</code>: A tuple, string, or <code>Commit</code> object representing the
-commit.</li>
-<li><code>block_state</code>: Causes inspect commit to block until the commit is in
-the desired commit state.</li>
+commit. </li>
+<li>An optional int that causes this method to block until the commit is
+in the desired commit state. See the <code>CommitState</code> enum.</li>
 </ul>
 </div>
   <div class="source_cont">
@@ -6530,8 +6530,8 @@ prefix username with "robot:". If 'username' has no prefix (i.e.
 no ":"), then it's assumed to be a github user's principal.</li>
 <li><code>repo</code>: A string specifying the object to which <code>username</code>s access
 level is being granted/revoked.</li>
-<li><code>scope</code>: A <code>Scope</code> object specifying the access level that
-<code>username</code> will now have.</li>
+<li><code>scope</code>: An int specifying the access level that <code>username</code> will now
+have. See the <code>Scope</code> enum for variants.</li>
 </ul>
 </div>
   <div class="source_cont">

--- a/src/python_pachyderm/__init__.py
+++ b/src/python_pachyderm/__init__.py
@@ -47,10 +47,7 @@ def _import_protos(path):
 
         if isinstance(value, _EnumTypeWrapper):
             # Dynamically define an enum class that is exported
-            enum_values = _enum._EnumDict()
-            enum_values.update(dict(value.items()))
-            enum_class = type(key, (_enum.IntEnum,), enum_values)
-            g[key] = enum_class
+            g[key] = _enum.Enum(key, {k: v for (k, v) in value.items()})
         else:
             # Export the value
             g[key] = value

--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -142,8 +142,8 @@ class AuthMixin:
 
         * `repo`: A string specifying the repo name that the caller wants
         access to.
-        * `scope`: A `Scope` object specifying the access level that the
-        caller needs to perform an action.
+        * `scope`: An int specifying the access level that the caller needs to
+        perform an action. See the `Scope` enum for variants.
         """
         return self._req(Service.AUTH, "Authorize", repo=repo, scope=scope).authorized
 
@@ -184,8 +184,8 @@ class AuthMixin:
         no ":"), then it's assumed to be a github user's principal.
         * `repo`: A string specifying the object to which `username`s access
         level is being granted/revoked.
-        * `scope`: A `Scope` object specifying the access level that
-        `username` will now have.
+        * `scope`: An int specifying the access level that `username` will now
+        have. See the `Scope` enum for variants.
         """
         return self._req(Service.AUTH, "SetScope", username=username, repo=repo, scope=scope)
 

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -292,9 +292,9 @@ class PFSMixin:
         Params:
 
         * `commit`: A tuple, string, or `Commit` object representing the
-        commit.
-        * `block_state`: Causes inspect commit to block until the commit is in
-        the desired commit state.
+        commit. 
+        * An optional int that causes this method to block until the commit is
+        in the desired commit state. See the `CommitState` enum.
         """
         return self._req(Service.PFS, "InspectCommit", commit=commit_from(commit), block_state=block_state)
 

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -292,7 +292,7 @@ class PFSMixin:
         Params:
 
         * `commit`: A tuple, string, or `Commit` object representing the
-        commit. 
+        commit.
         * An optional int that causes this method to block until the commit is
         in the desired commit state. See the `CommitState` enum.
         """

--- a/src/python_pachyderm/mixin/util.py
+++ b/src/python_pachyderm/mixin/util.py
@@ -13,6 +13,3 @@ def commit_from(src, allow_just_repo=False):
     if not allow_just_repo:
         raise ValueError("Invalid commit type")
     return pfs_proto.Commit(repo=pfs_proto.Repo(name=src))
-
-def enum_value_from(value):
-    return value if isinstance(value, int) else value.value

--- a/src/python_pachyderm/mixin/util.py
+++ b/src/python_pachyderm/mixin/util.py
@@ -13,3 +13,6 @@ def commit_from(src, allow_just_repo=False):
     if not allow_just_repo:
         raise ValueError("Invalid commit type")
     return pfs_proto.Commit(repo=pfs_proto.Repo(name=src))
+
+def enum_value_from(value):
+    return value if isinstance(value, int) else value.value

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -56,7 +56,7 @@ def test_one_time_password():
 @util.skip_if_no_enterprise()
 def test_authorize():
     with sandbox() as client:
-        assert client.authorize("foobar", python_pachyderm.Scope.READER)
+        assert client.authorize("foobar", python_pachyderm.Scope.READER.value)
 
 @util.skip_if_no_enterprise()
 def test_who_am_i():
@@ -70,10 +70,10 @@ def test_scope():
     with sandbox() as client:
         repo = util.create_test_repo(client, "test_scope")
         scopes = client.get_scope("robot:root", repo)
-        assert all(s == python_pachyderm.Scope.NONE for s in scopes)
-        client.set_scope("robot:root", repo, python_pachyderm.Scope.READER)
+        assert all(s == python_pachyderm.Scope.NONE.value for s in scopes)
+        client.set_scope("robot:root", repo, python_pachyderm.Scope.READER.value)
         scopes = client.get_scope("robot:root", repo)
-        assert all(s == python_pachyderm.Scope.NONE for s in scopes)
+        assert all(s == python_pachyderm.Scope.NONE.value for s in scopes)
 
 @util.skip_if_no_enterprise()
 def test_acl():
@@ -82,7 +82,7 @@ def test_acl():
         assert len(acl.entries) == 1
         assert len(acl.robot_entries) == 0
         assert acl.entries[0].username == "robot:root"
-        assert acl.entries[0].scope == python_pachyderm.Scope.OWNER
+        assert acl.entries[0].scope == python_pachyderm.Scope.OWNER.value
         return acl
 
     with sandbox() as client:

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -14,5 +14,5 @@ from tests import util
 def test_enterprise():
     client = python_pachyderm.Client()
     client.activate_enterprise(os.environ["PACH_PYTHON_ENTERPRISE_CODE"])
-    assert client.get_enterprise_state().state == python_pachyderm.State.ACTIVE
+    assert client.get_enterprise_state().state == python_pachyderm.State.ACTIVE.value
     client.deactivate_enterprise()

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -366,10 +366,10 @@ def test_list_file():
     files = list(client.list_file(c, '/'))
     assert len(files) == 2
     assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE
+    assert files[0].file_type == python_pachyderm.FileType.FILE.value
     assert files[0].file.path == "/file1.dat"
     assert files[1].size_bytes == 4
-    assert files[1].file_type == python_pachyderm.FileType.FILE
+    assert files[1].file_type == python_pachyderm.FileType.FILE.value
     assert files[1].file.path == "/file2.dat"
 
 def test_walk_file():
@@ -397,16 +397,16 @@ def test_glob_file():
     files = list(client.glob_file(c, '/*.dat'))
     assert len(files) == 2
     assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE
+    assert files[0].file_type == python_pachyderm.FileType.FILE.value
     assert files[0].file.path == "/file1.dat"
     assert files[1].size_bytes == 4
-    assert files[1].file_type == python_pachyderm.FileType.FILE
+    assert files[1].file_type == python_pachyderm.FileType.FILE.value
     assert files[1].file.path == "/file2.dat"
 
     files = list(client.glob_file(c, '/*1.dat'))
     assert len(files) == 1
     assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE
+    assert files[0].file_type == python_pachyderm.FileType.FILE.value
     assert files[0].file.path == "/file1.dat"
 
 def test_delete_file():

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -59,7 +59,7 @@ def test_stop_job():
     except:
         # if it failed, it should be because the job already finished
         job = sandbox.client.inspect_job(job_id)
-        assert job.state == python_pachyderm.JobState.JOB_SUCCESS
+        assert job.state == python_pachyderm.JobState.JOB_SUCCESS.value
     else:
         # This is necessary because `StopJob` does not wait for the job to be
         # killed before returning a result.
@@ -67,7 +67,7 @@ def test_stop_job():
         # https://github.com/pachyderm/pachyderm/issues/3856
         time.sleep(1)
         job = sandbox.client.inspect_job(job_id)
-        assert job.state == python_pachyderm.JobState.JOB_KILLED
+        assert job.state == python_pachyderm.JobState.JOB_KILLED.value
 
 def test_delete_job():
     sandbox = Sandbox("delete_job")
@@ -86,7 +86,7 @@ def test_datums():
     datums = list(sandbox.client.list_datum(job_id))
     assert len(datums) == 1
     datum = sandbox.client.inspect_datum(job_id, datums[0].datum_info.datum.id)
-    assert datum.state == python_pachyderm.DatumState.SUCCESS
+    assert datum.state == python_pachyderm.DatumState.SUCCESS.value
 
     # Skip this check in >=1.11.0, due to a bug:
     # https://github.com/pachyderm/pachyderm/issues/5123

--- a/tests/util.py
+++ b/tests/util.py
@@ -64,7 +64,7 @@ def create_test_pipeline(client, test_name):
 
 def wait_for_job(client, commit):
     # block until the commit is ready
-    client.inspect_commit(commit, block_state=python_pachyderm.CommitState.READY)
+    client.inspect_commit(commit, block_state=python_pachyderm.CommitState.READY.value)
 
     # while the commit is ready, the job might not be listed on the first
     # call, so repeatedly list jobs until it's available


### PR DESCRIPTION
This changes how we dynamically generated enums from protos, such that the enum variants are documented and exposed via introspection (e.g. `dir(EnumClass)`.) The downside is that this removes some magic that allowed our functions to take in enum variants directly rather than ints. As a result, affected functions need to accept `enum_variant.value` -- see the tests for examples. This is a breaking change, and will be batched together with the other breaking changes in open PRs.