### PR TITLE
Switch to `pip download` instead of `pip wheel`

### DIFF
--- a/src/python_pachyderm/util.py
+++ b/src/python_pachyderm/util.py
@@ -11,7 +11,7 @@ RUNNER_SCRIPT_WITH_WHEELS = """
 set -{set_args}
 
 cd /pfs/{source_repo_name}
-pip install /pfs/{build_pipeline_name}/*.whl
+pip install /pfs/{build_pipeline_name}/*.whl /pfs/{build_pipeline_name}/*.tar.gz
 python main.py
 """
 
@@ -34,7 +34,7 @@ python --version
 pip --version
 
 cd /pfs/{source_repo_name}
-test -f requirements.txt && pip wheel -r requirements.txt -w /pfs/out
+test -f requirements.txt && pip download -r requirements.txt -d /pfs/out
 """
 
 


### PR DESCRIPTION
I've been wrestling for a while with the fact that the following fairly typical `requirements.txt` fails with `create_python_pipeline`:
```
scikit-learn == 0.20.3
numpy >= 1.8.2
joblib >= 0.13.0
pandas >= 1.0.1
PyYAML >= 5.3
```
The problematic package is `scikit-learn`, which fails to `wheel` with the build error below.
This PR fixes it in my testing, by switching `pip wheel` to `pip download`, and updating `pip install` to tolerate the fact that sometimes `pip download` downloads tarballs, not `whl` files (PyYAML in particular was like this).

I'd appreciate a careful review as this may break other `requirements.txt` files in subtle and unexpected ways. In particular, does `pip download` ever download things other than `whl` or `tar.gz`?

Also for longer term consideration, explicit support for auto-building Docker images may be less painful to implement than trying to make python packaging save/restore work reliably in all cases.

---
## Build error

```
Building wheels for collected packages: scikit-learn, PyYAML
  Building wheel for scikit-learn (setup.py): started
  Building wheel for scikit-learn (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-wheel-w3p3415d/scikit-learn/setup.py'"'"'; __file__='"'"'/tmp/pip-wheel-w3p3415d/scikit-learn/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-mwq7pa_z
       cwd: /tmp/pip-wheel-w3p3415d/scikit-learn/
  Complete output (15 lines):
  Partial import of sklearn during the build process.
  Traceback (most recent call last):
    File "/tmp/pip-wheel-w3p3415d/scikit-learn/setup.py", line 153, in get_numpy_status
      import numpy
  ModuleNotFoundError: No module named 'numpy'
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-wheel-w3p3415d/scikit-learn/setup.py", line 250, in <module>
      setup_package()
    File "/tmp/pip-wheel-w3p3415d/scikit-learn/setup.py", line 238, in setup_package
      raise ImportError("Numerical Python (NumPy) is not "
  ImportError: Numerical Python (NumPy) is not installed.
  scikit-learn requires NumPy >= 1.8.2.
  Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html
  
  ----------------------------------------
  ERROR: Failed building wheel for scikit-learn
  Running setup.py clean for scikit-learn
  Building wheel for PyYAML (setup.py): started
  Building wheel for PyYAML (setup.py): finished with status 'done'
  Created wheel for PyYAML: filename=PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl size=572466 sha256=a24187ba8af63390e58ad4622a76bd88f95cae7de244d59328500fc2ac74def0
  Stored in directory: /root/.cache/pip/wheels/13/90/db/290ab3a34f2ef0b5a0f89235dc2d40fea83e77de84ed2dc05c
Successfully built PyYAML
Failed to build scikit-learn
ERROR: Failed to build one or more wheels
```