### PR TITLE
Pin opencv version

### DIFF
--- a/examples/opencv/edges/requirements.txt
+++ b/examples/opencv/edges/requirements.txt
@@ -1,2 +1,2 @@
 matplotlib>=3.1.2
-opencv-python>=4.1.2.30
+opencv-python==4.3.0.36


### PR DESCRIPTION
The latest release of opencv appears to have issues running on a vanilla `python:3` image, so this change pins to the prior version of opencv.