### PR TITLE
Make python spout manager tolerant of exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ However, if for whatever reason you need to know which version of pachyderm core
 
 ## Contributing
 
-This driver is co-maintained by Pachyderm and the community. If you're looking to contribute to the project, this is a fantastic place to get involved. Take a look at [the contributing guide](./contributing.md) for more info.
+This driver is co-maintained by Pachyderm and the community. If you're looking to contribute to the project, this is a fantastic place to get involved. Take a look at [the contributing guide](./contributing.md) for more info (including testing instructions).

--- a/contributing.md
+++ b/contributing.md
@@ -86,11 +86,17 @@ locally it's usually more convenient to run specific tests. To do so:
     * `protobuf>=3.11.2`
     * `grpcio>=1.26.0`
     * `certifi>=2019.11.28`
+* Alternatively, you can use `tox` to create a virtual environment for you:
+  ```
+  mkdir venvdir
+  tox --devenv venvdir -e py38 # one possible environment
+  source ./venvdir/bin/activate # activate python environment
+  ```
 * Install python-pachyderm into the virtualenv: `pip install -e .`
 * Start the cluster to run on `localhost:30650` -- if the cluster is not
 exposed on `localhost`, you can use `pachctl port-forward` to proxy
 connections.
-* Run the test: `py.test tests -k <test name>`
+* Run the test: `python3 -m pytest tests -k <test name>`
 
 ### Linting
 

--- a/src/python_pachyderm/spout.py
+++ b/src/python_pachyderm/spout.py
@@ -64,7 +64,7 @@ class SpoutManager:
             yield spout_commit
         finally:
             spout_commit.close()
-        self._has_open_commit = False
+            self._has_open_commit = False
 
 
 class SpoutCommit:

--- a/src/python_pachyderm/spout.py
+++ b/src/python_pachyderm/spout.py
@@ -60,8 +60,10 @@ class SpoutManager:
             raise Exception("spout commit context manager already opened")
         spout_commit = SpoutCommit(self._pipe, marker_filename=self.marker_filename)
         self._has_open_commit = True
-        yield spout_commit
-        spout_commit.close()
+        try:
+            yield spout_commit
+        finally:
+            spout_commit.close()
         self._has_open_commit = False
 
 

--- a/tests/test_spout.py
+++ b/tests/test_spout.py
@@ -6,6 +6,8 @@ import tempfile
 
 import pytest
 import python_pachyderm
+import tarfile
+from os.path import join
 
 
 def test_spout_manager():
@@ -15,9 +17,26 @@ def test_spout_manager():
         with manager.commit() as commit:
             commit.put_file_from_bytes("foo1.txt", b"bar1")
             commit.put_marker_from_bytes(b"marker1")
+
+        # Validate output
+        with tarfile.open(join(d, "out"), "r:") as t:
+            with t.extractfile("foo1.txt") as x:
+                assert x.read() == b"bar1"
+            with t.extractfile("marker") as x:
+                assert x.read() == b"marker1"
+
         with manager.commit() as commit:
             commit.put_file_from_bytes("foo2.txt", b"bar2")
             commit.put_marker_from_bytes(b"marker2")
+
+        # Validate output (note that because the most recent writes simply
+        # appended to the existing tar file, we must set ignore_zeros to ignore
+        # the extra padding before the second set of tar headers)
+        with tarfile.open(join(d, "out"), "r:", ignore_zeros=True) as t:
+            with t.extractfile("foo2.txt") as x:
+                assert x.read() == b"bar2"
+            with t.extractfile("marker") as x:
+                assert x.read() == b"marker2"
 
 def test_spout_manager_nested_commits():
     with tempfile.TemporaryDirectory(suffix="pachyderm") as d:
@@ -35,8 +54,21 @@ def test_spout_manager_commit_state():
     with tempfile.TemporaryDirectory(suffix="pachyderm") as d:
         manager = python_pachyderm.SpoutManager(pfs_directory=d, marker_filename="marker")
 
-        with pytest.raises(Exception):
-            with manager.commit() as commit:
-                raise Exception()
+        for _ in range(3):
+            with pytest.raises(Exception):
+                with manager.commit() as commit:
+                    raise Exception()
+            assert not manager._has_open_commit
 
-        assert manager._has_open_commit
+        # Now try to use the spout manager normally & confirm it still works
+        with manager.commit() as commit:
+            commit.put_file_from_bytes("foo1.txt", b"bar1")
+            commit.put_marker_from_bytes(b"marker1")
+
+        # Validate output. See note above re:ignore_zeros
+        with tarfile.open(join(d, "out"), "r:", ignore_zeros=True) as t:
+            with t.extractfile("foo1.txt") as x:
+                assert x.read() == b"bar1"
+            with t.extractfile("marker") as x:
+                assert x.read() == b"marker1"
+


### PR DESCRIPTION
Just creating this PR in preparation for the oncall handoff. We probably need a test for this as well, plus a new release