### PR TITLE
client.py - added check of "/pachctl/config.json" in  new_from_config() function

### DIFF
--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -161,8 +161,14 @@ class Client(
         """
 
         if config_file is None:
-            with open(str(Path.home() / ".pachyderm/config.json"), "r") as config_file:
-                j = json.load(config_file)
+            try:
+                # Search for config file in default home location 
+                with open(str(Path.home() / ".pachyderm/config.json"), "r") as config_file:
+                    j = json.load(config_file)
+            except FileNotFoundError:
+                # If not found, search in "/pachctl" (default mount for spout)
+                with open("/pachctl/config.json", "r") as config_file:
+                    j = json.load(config_file)
         else:
             j = json.load(config_file)
 


### PR DESCRIPTION
When no config.json file is passed as parameter of `new_from_config()` in client.py, 
the config file is first searched in `~/pachyderm/config.json` then `/pachctl/config.json`

Tested locally AND on hub 1.12.0 with spout 2.0 example 
https://github.com/pachyderm/pachyderm/pull/5556