### PR TITLE
add the omitted metadata field to the create_pipeline return

### DIFF
--- a/src/python_pachyderm/mixin/pps.py
+++ b/src/python_pachyderm/mixin/pps.py
@@ -302,6 +302,7 @@ class PPSMixin:
             enable_stats=enable_stats,
             reprocess=reprocess,
             max_queue_size=max_queue_size,
+            metadata=metadata,
             service=service,
             chunk_spec=chunk_spec,
             datum_timeout=datum_timeout,


### PR DESCRIPTION
Metadata was not being returned from pipeline creation and was being left at default value "None"