### PR TITLE
CI is green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ jobs:
       env:
         - TOXENV=lint
         - PACHYDERM_VERSION=1.12.4
-    - python: 3.8
-      env:
-        - TOXENV=examples
-        - PACHYDERM_VERSION=1.12.4
 
 install:
 - make ci-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,11 @@ jobs:
       env:
         - TOXENV=lint
         - PACHYDERM_VERSION=1.12.4
-
+    # Re-enable examples once 1.12.6 is released with libgl in the python build image
+    #- python: 3.8
+    #  env:
+    #    - TOXENV=examples
+    #    - PACHYDERM_VERSION=1.12.4
 install:
 - make ci-install
 before_script:

--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -166,7 +166,7 @@ class Client(
 
         if config_file is None:
             try:
-                # Search for config file in default home location 
+                # Search for config file in default home location
                 with open(str(Path.home() / ".pachyderm/config.json"), "r") as config_file:
                     j = json.load(config_file)
             except FileNotFoundError:


### PR DESCRIPTION
Remove the examples until we have 1.12.6, and remove trailing whitespace that causes a linter error.