### PR TITLE
Fix log tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 - tox
 after_script:
 - kubectl describe pods
+- kubectl logs --previous deployment/pachd
 
 before_cache:
   # Make sure cache dirs have the necessary permissions for Travis to traverse

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_script:
 - make ci-setup
 script:
 - tox
+after_script:
+- kubectl describe pods
 
 before_cache:
   # Make sure cache dirs have the necessary permissions for Travis to traverse

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PATH=$HOME/cached-deps:$PATH
   jobs:
-    - PACHYDERM_VERSION=1.12.4
+    - PACHYDERM_VERSION=1.12.5
     - PACHYDERM_VERSION=1.11.9
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
     - python: 3.8
       env:
         - TOXENV=lint
-        - PACHYDERM_VERSION=1.12.4
+        - PACHYDERM_VERSION=1.12.5
     # Re-enable examples once 1.12.6 is released with libgl in the python build image
     #- python: 3.8
     #  env:

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -173,33 +173,33 @@ def test_secrets():
     secrets = client.list_secret()
     assert len(secrets) == 0
 
-#def test_get_pipeline_logs():
-#    sandbox = Sandbox("get_pipeline_logs")
-#    job_id = sandbox.wait_for_job()
-#
-#    # Wait for the job to complete
-#    list(sandbox.client.flush_job([sandbox.commit]))
-#
-#    # Just make sure these spit out some logs
-#    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name)
-#    assert next(logs) is not None
-#
-#    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name, master=True)
-#    assert next(logs) is not None
+def test_get_pipeline_logs():
+    sandbox = Sandbox("get_pipeline_logs")
+    job_id = sandbox.wait_for_job()
+
+    # Wait for the job to complete
+    list(sandbox.client.flush_job([sandbox.commit]))
+
+    # Just make sure these spit out some logs
+    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name)
+    assert next(logs) is not None
+
+    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name, master=True)
+    assert next(logs) is not None
 
 # job logs are available in 1.8.x, but they frequently fail due to bugs that
 # are resolved in 1.9.0
-#@util.skip_if_below_pachyderm_version(1, 9, 0)
-#def test_get_job_logs():
-#    sandbox = Sandbox("get_logs_logs")
-#    job_id = sandbox.wait_for_job()
-#
-#    # Wait for the job to complete
-#    list(sandbox.client.flush_job([sandbox.commit]))
-#
-#    # Just make sure these spit out some logs
-#    logs = sandbox.client.get_job_logs(job_id)
-#    assert next(logs) is not None
+@util.skip_if_below_pachyderm_version(1, 9, 0)
+def test_get_job_logs():
+    sandbox = Sandbox("get_logs_logs")
+    job_id = sandbox.wait_for_job()
+
+    # Wait for the job to complete
+    list(sandbox.client.flush_job([sandbox.commit]))
+
+    # Just make sure these spit out some logs
+    logs = sandbox.client.get_job_logs(job_id)
+    assert next(logs) is not None
 
 def test_create_pipeline_from_request():
     client = python_pachyderm.Client()


### PR DESCRIPTION
There's a bug in the 1.12.4 server which causes a stack trace if the client doesn't set `Since` in the `GetLogsRequest`. This is fixed in 1.12.5.