### PR TITLE
Support root_token

### DIFF
--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -32,8 +32,6 @@ class AuthMixin:
           we find a use for it (feel free to file an issue in
           github.com/pachyderm/pachyderm)
         """
-        if root_token is not None:
-            raise NotImplementedError('root_token is not supported in python_pachyderm')
         return self._req(Service.AUTH, "Activate", subject=subject, github_token=github_token).pach_token
 
     def deactivate_auth(self):


### PR DESCRIPTION
I blocked `root_token` in https://github.com/pachyderm/python-pachyderm/pull/249, but I'm not sure if that was the right thing do on a product level. This PR undoes that, so that that decision can easily be reversed before releasing 6.1.0.

If we like that `root_token` is disabled, then we can just release without merging this PR (and delete it)