### PR TITLE
Issue-255: Update get_file to accept new format [WIP]

### DIFF
--- a/src/python_pachyderm/mixin/util.py
+++ b/src/python_pachyderm/mixin/util.py
@@ -13,3 +13,14 @@ def commit_from(src, allow_just_repo=False):
     if not allow_just_repo:
         raise ValueError("Invalid commit type")
     return pfs_proto.Commit(repo=pfs_proto.Repo(name=src))
+
+def pfs_file_from_str(pfs_obj_ref):
+    """
+    pfs_str is of format <repo>@<commit-or-branch>:<file>
+    """
+    repo, commit_and_path = pfs_obj_ref.split("@", 1)
+    commit, path = commit_and_path.split(":", 1)
+    return pfs_proto.File(
+        commit=pfs_proto.Commit(repo=pfs_proto.Repo(name=repo), id=commit),
+        path=path,
+    )


### PR DESCRIPTION
Where new format is `<repo>@<commit-or-branch>:<file>`. We want the client to specify files in PFS in a way that is consistent with `pachctl`.

However, this is a breaking API change. In addition to `get_file` there are many other places that needs to be updated to use the new path format.

Relates to #255