### PR TITLE
Clean up resources in K8s before running test

### DIFF
--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -13,6 +13,7 @@ from tests import util
 class Sandbox:
     def __init__(self, test_name):
         client = python_pachyderm.Client()
+        client.delete_all()
         commit, input_repo_name, pipeline_repo_name = util.create_test_pipeline(client, test_name)
         self.client = client
         self.commit = commit


### PR DESCRIPTION
This way, we don't run into issues with resource contention between tests, and keeps tests isolated.