### PR TITLE
Fix PFSFile inf iter

### DIFF
--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -73,13 +73,17 @@ class PFSFile:
         # files, e.g. when getting a directory) as a tar stream--untar the
         # response byte stream as we receive it from GetFile.
         f = tarfile.open(fileobj=stream, mode="r|*")
+        # TODO how to handle multiple files in the tar stream?
         self._file = f.extractfile(f.next())
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        return self.read()
+        x = self.read()
+        if not x:
+            raise StopIteration
+        return x
 
     def read(self, size=-1):
         return self._file.read(size)

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -313,6 +313,16 @@ def test_get_file():
     assert client.get_file(commit, "file1.dat").read() == b"DATA1"
 
 
+def test_PFSFile_iter():
+    client, repo_name = sandbox("put_file_atomic")
+    commit = (repo_name, "master")
+
+    with client.modify_file_client(commit) as pfc:
+        pfc.put_file_from_fileobj("file1.dat", BytesIO(b"DATA1"))
+
+    assert list(client.get_file(commit, "file1.dat"))[0] == b"DATA1"
+
+
 def test_copy_file():
     client, repo_name = sandbox("copy_file")
 


### PR DESCRIPTION
Currently if we try iterating on a PFSFile, it would result in an inf non-terminating loop because we don't ever raise `StopIteration`. This was introduced as a stop gap measure to make PFSFile conform to Pandas' definition of a "file-like obj".

I think there are a couple of different ways we can go about this:
1. We actually make PFSFile an iterator by implementing `__iter__` and `__next__`
2. We don't make PFSFile an iterator, but just add an `__iter__` stub method to conform to Pandas' specs

This PR currently goes with option 1.