### PR TITLE
Fix broken tests by explicitly importing protos

### DIFF
--- a/examples/opencv/opencv.py
+++ b/examples/opencv/opencv.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import tempfile
 import python_pachyderm
+from python_pachyderm.service import pps_proto
 
 
 def relpath(path):
@@ -36,33 +37,27 @@ def main():
 
     client.create_pipeline(
         "edges",
-        transform=python_pachyderm.Transform(
+        transform=pps_proto.Transform(
             cmd=["python3", "/edges.py"],
             image="pachyderm/opencv",
         ),
-        input=python_pachyderm.Input(
-            pfs=python_pachyderm.PFSInput(repo="images", glob="/*")
-        ),
+        input=pps_proto.Input(pfs=pps_proto.PFSInput(repo="images", glob="/*")),
     )
 
     # Create the montage pipeline
     client.create_pipeline(
         "montage",
-        transform=python_pachyderm.Transform(
+        transform=pps_proto.Transform(
             cmd=["sh"],
             image="v4tech/imagemagick",
             stdin=[
                 "montage -shadow -background SkyBlue -geometry 300x300+2+2 $(find /pfs -type f | sort) /pfs/out/montage.png"
             ],
         ),
-        input=python_pachyderm.Input(
+        input=pps_proto.Input(
             cross=[
-                python_pachyderm.Input(
-                    pfs=python_pachyderm.PFSInput(glob="/", repo="images")
-                ),
-                python_pachyderm.Input(
-                    pfs=python_pachyderm.PFSInput(glob="/", repo="edges")
-                ),
+                pps_proto.Input(pfs=pps_proto.PFSInput(glob="/", repo="images")),
+                pps_proto.Input(pfs=pps_proto.PFSInput(glob="/", repo="edges")),
             ]
         ),
     )

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,13 +2,11 @@
 
 """Tests admin-related functionality"""
 
-import pytest
-
 import python_pachyderm
-from tests import util
+from python_pachyderm.proto.v2.admin import admin_pb2
 
 
 def test_inspect_cluster():
     client = python_pachyderm.Client()
     res = client.inspect_cluster()
-    assert isinstance(res, python_pachyderm.ClusterInfo)
+    assert isinstance(res, admin_pb2.ClusterInfo)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -74,7 +74,7 @@ def test_cluster_role_bindings(client):
 def test_authorize(client):
     client.authorize(
         auth_pb2.Resource(type=auth_pb2.REPO, name="foobar"),
-        [python_pachyderm.Permission.REPO_READ.value],
+        [auth_pb2.Permission.REPO_READ],
     )
 
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -3,6 +3,7 @@
 """Tests debug-related functionality"""
 
 import python_pachyderm
+from google.protobuf import duration_pb2
 
 
 def test_dump():
@@ -14,7 +15,7 @@ def test_dump():
 
 def test_profile_cpu():
     client = python_pachyderm.Client()
-    for b in client.profile_cpu(python_pachyderm.Duration(seconds=1)):
+    for b in client.profile_cpu(duration_pb2.Duration(seconds=1)):
         assert isinstance(b, bytes)
         assert len(b) > 0
 

--- a/tests/test_enterprise.py
+++ b/tests/test_enterprise.py
@@ -4,9 +4,8 @@
 
 import os
 
-import pytest
-
 import python_pachyderm
+from python_pachyderm.proto.v2.enterprise import enterprise_pb2
 from tests import util
 
 
@@ -17,6 +16,6 @@ def test_enterprise():
     client.activate_license(os.environ["PACH_PYTHON_ENTERPRISE_CODE"])
     client.add_cluster("localhost", "localhost:650", secret="secret")
     client.activate_enterprise("localhost:650", "localhost", "secret")
-    assert client.get_enterprise_state().state == python_pachyderm.State.ACTIVE.value
+    assert client.get_enterprise_state().state == enterprise_pb2.State.ACTIVE
     client.deactivate_enterprise()
     client.delete_all_license()

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -7,6 +7,7 @@ import tempfile
 from io import BytesIO
 
 import python_pachyderm
+from python_pachyderm.proto.v2.pfs import pfs_pb2
 from tests import util
 
 
@@ -442,10 +443,10 @@ def test_list_file():
     files = list(client.list_file((repo_name, c.id), "/"))
     assert len(files) == 2
     # assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE.value
+    assert files[0].file_type == pfs_pb2.FileType.FILE
     assert files[0].file.path == "/file1.dat"
     # assert files[1].size_bytes == 4
-    assert files[1].file_type == python_pachyderm.FileType.FILE.value
+    assert files[1].file_type == pfs_pb2.FileType.FILE
     assert files[1].file.path == "/file2.dat"
 
 
@@ -475,16 +476,16 @@ def test_glob_file():
     files = list(client.glob_file(c, "/*.dat"))
     assert len(files) == 2
     # assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE.value
+    assert files[0].file_type == pfs_pb2.FileType.FILE
     assert files[0].file.path == "/file1.dat"
     # assert files[1].size_bytes == 4
-    assert files[1].file_type == python_pachyderm.FileType.FILE.value
+    assert files[1].file_type == pfs_pb2.FileType.FILE
     assert files[1].file.path == "/file2.dat"
 
     files = list(client.glob_file(c, "/*1.dat"))
     assert len(files) == 1
     # assert files[0].size_bytes == 4
-    assert files[0].file_type == python_pachyderm.FileType.FILE.value
+    assert files[0].file_type == pfs_pb2.FileType.FILE
     assert files[0].file.path == "/file1.dat"
 
 

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -97,7 +97,7 @@ def test_datums():
     datums = list(sandbox.client.list_datum(job_id))
     assert len(datums) == 1
     datum = sandbox.client.inspect_datum(job_id, datums[0].datum.id)
-    assert datum.state == python_pachyderm.DatumState.SUCCESS.value
+    assert datum.state == pps_pb2.DatumState.SUCCESS
 
     with pytest.raises(
         python_pachyderm.RpcError,
@@ -173,9 +173,10 @@ def test_run_cron():
     # this should trigger an error because the sandbox pipeline doesn't have a
     # cron input
     # NOTE: `e` is used after the context
-    with pytest.raises(python_pachyderm.RpcError) as e:
+    with pytest.raises(
+        python_pachyderm.RpcError, match=r"pipeline must have a cron input"
+    ):
         sandbox.client.run_cron(sandbox.pipeline_repo_name)
-    assert "pipeline must have a cron input" in str(e.value)
 
 
 def test_secrets():
@@ -240,16 +241,16 @@ def test_create_pipeline_from_request():
 
     # more or less a copy of the opencv demo's edges pipeline spec
     client.create_pipeline_from_request(
-        python_pachyderm.CreatePipelineRequest(
-            pipeline=python_pachyderm.Pipeline(name=pipeline_name),
+        pps_pb2.CreatePipelineRequest(
+            pipeline=pps_pb2.Pipeline(name=pipeline_name),
             description="A pipeline that performs image edge detection by using the OpenCV library.",
-            input=python_pachyderm.Input(
-                pfs=python_pachyderm.PFSInput(
+            input=pps_pb2.Input(
+                pfs=pps_pb2.PFSInput(
                     glob="/*",
                     repo=repo_name,
                 ),
             ),
-            transform=python_pachyderm.Transform(
+            transform=pps_pb2.Transform(
                 cmd=["echo", "hi"],
                 image="pachyderm/opencv",
             ),

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -5,7 +5,8 @@
 import pytest
 
 import python_pachyderm
-
+from python_pachyderm.proto.v2.pfs import pfs_pb2
+from python_pachyderm.proto.v2.transaction import transaction_pb2
 from tests import util
 
 
@@ -14,11 +15,9 @@ def test_batch_transaction():
     expected_repo_count = len(client.list_repo()) + 3
 
     def create_repo_request():
-        return python_pachyderm.TransactionRequest(
-            create_repo=python_pachyderm.CreateRepoRequest(
-                repo=python_pachyderm.Repo(
-                    name=util.test_repo_name("test_batch_transaction")
-                )
+        return transaction_pb2.TransactionRequest(
+            create_repo=pfs_pb2.CreateRepoRequest(
+                repo=pfs_pb2.Repo(name=util.test_repo_name("test_batch_transaction"))
             )
         )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,9 +6,8 @@ import os
 import json
 import tempfile
 
-import pytest
-
 import python_pachyderm
+from python_pachyderm.proto.v2.pps import pps_pb2
 from tests import util
 
 # script that copies a file using just stdlibs
@@ -118,13 +117,13 @@ def test_parse_dict_pipeline_spec():
 
 
 def check_pipeline_spec(req):
-    assert req == python_pachyderm.CreatePipelineRequest(
-        pipeline=python_pachyderm.Pipeline(name="foobar"),
+    assert req == pps_pb2.CreatePipelineRequest(
+        pipeline=pps_pb2.Pipeline(name="foobar"),
         description="A pipeline that performs image edge detection by using the OpenCV library.",
-        input=python_pachyderm.Input(
-            pfs=python_pachyderm.PFSInput(glob="/*", repo="images"),
+        input=pps_pb2.Input(
+            pfs=pps_pb2.PFSInput(glob="/*", repo="images"),
         ),
-        transform=python_pachyderm.Transform(
+        transform=pps_pb2.Transform(
             cmd=["python3", "/edges.py"],
             image="pachyderm/opencv",
         ),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,6 +7,7 @@ from os.path import join
 from os.path import dirname
 
 import python_pachyderm
+from python_pachyderm.proto.v2.version.versionpb import version_pb2
 
 
 def test_local_version():
@@ -18,4 +19,4 @@ def test_local_version():
 
 def test_remote_version():
     version_pb = python_pachyderm.Client().get_remote_version()
-    assert isinstance(version_pb, python_pachyderm.Version)
+    assert isinstance(version_pb, version_pb2.Version)

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,7 +4,10 @@ import string
 import random
 
 import pytest
+
 import python_pachyderm
+from python_pachyderm.proto.v2.pfs import pfs_pb2
+from python_pachyderm.proto.v2.pps import pps_pb2
 
 _test_pachyderm_version = None
 
@@ -65,14 +68,12 @@ def create_test_pipeline(client, test_name):
 
     client.create_pipeline(
         pipeline_repo_name,
-        transform=python_pachyderm.Transform(
+        transform=pps_pb2.Transform(
             cmd=["sh"],
             image="alpine",
             stdin=["cp /pfs/{}/*.dat /pfs/out/".format(input_repo_name)],
         ),
-        input=python_pachyderm.Input(
-            pfs=python_pachyderm.PFSInput(glob="/*", repo=input_repo_name)
-        ),
+        input=pps_pb2.Input(pfs=pps_pb2.PFSInput(glob="/*", repo=input_repo_name)),
         enable_stats=True,
     )
 
@@ -84,7 +85,7 @@ def create_test_pipeline(client, test_name):
 
 def wait_for_job(client: python_pachyderm.Client, commit):
     # block until the commit is ready
-    client.inspect_commit(commit, block_state=python_pachyderm.CommitState.READY.value)
+    client.inspect_commit(commit, block_state=pfs_pb2.CommitState.READY)
 
     # while the commit is ready, the job might not be listed on the first
     # call, so repeatedly list jobs until it's available


### PR DESCRIPTION
Master is broken because we no longer dynamically import protobuf objects.
https://github.com/pachyderm/python-pachyderm/blob/d8c4035033965a07204995d642d7225b7d80ef63/src/python_pachyderm/__init__.py#L95-L103

This was intentional because we don't want doc parsers to include these, but also we don't want to leak protobuf details in general.