### PR TITLE
[PFS] Add functionality to put_files to support putting individual files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ src/python_pachyderm/version.py
 
 # virtualenv
 venv
+.python-version

--- a/src/python_pachyderm/util.py
+++ b/src/python_pachyderm/util.py
@@ -8,13 +8,13 @@ from python_pachyderm.proto.v2.pps.pps_pb2 import CreatePipelineRequest
 
 def put_files(client: Client, source_path, commit, dest_path, **kwargs):
     """
-    Utility function for recursively inserting files from the local
-    `source_path` to pachyderm. Roughly equivalent to `pachctl put file -r`.
+    Utility function for inserting files from the local `source_path`
+    to pachyderm. Roughly equivalent to `pachctl put file [-r]`.
 
     Params:
 
     * `client`: The `Client` instance to use.
-    * `source_path`: The directory to recursively insert content from.
+    * `source_path`: The file/directory to recursively insert content from.
     * `commit`: The `Commit` object to use for inserting files.
     * `dest_path`: The destination path in PFS.
     * `kwargs`: Keyword arguments to forward. See
@@ -22,13 +22,18 @@ def put_files(client: Client, source_path, commit, dest_path, **kwargs):
     """
 
     with client.modify_file_client(commit) as pfc:
-        for root, _, filenames in os.walk(source_path):
-            for filename in filenames:
-                source_filepath = os.path.join(root, filename)
-                dest_filepath = os.path.join(
-                    dest_path, os.path.relpath(source_filepath, start=source_path)
-                )
-                pfc.put_file_from_filepath(dest_filepath, source_filepath, **kwargs)
+        if os.path.isfile(source_path):
+            pfc.put_file_from_filepath(dest_path, source_path, **kwargs)
+        elif os.path.isdir(source_path):
+            for root, _, filenames in os.walk(source_path):
+                for filename in filenames:
+                    source_filepath = os.path.join(root, filename)
+                    dest_filepath = os.path.join(
+                        dest_path, os.path.relpath(source_filepath, start=source_path)
+                    )
+                    pfc.put_file_from_filepath(dest_filepath, source_filepath, **kwargs)
+        else:
+            raise Exception("Please provide an existing directory or file")
 
 
 def parse_json_pipeline_spec(j):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -106,6 +106,22 @@ def test_put_files():
     check_expected_files(client, commit, expected)
 
 
+def test_put_files_single_file():
+    client = python_pachyderm.Client()
+    client.delete_all()
+    repo_name = util.create_test_repo(client, "put_files_single_file")
+
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b"abcd")
+        f.flush()
+        commit = (repo_name, "master")
+        python_pachyderm.put_files(client, f.name, commit, "/f1.txt")
+        python_pachyderm.put_files(client, f.name, commit, "/f/f1")
+
+    expected = set(["/", "/f1.txt", "/f/", "/f/f1"])
+    check_expected_files(client, commit, expected)
+
+
 def test_parse_json_pipeline_spec():
     req = python_pachyderm.parse_json_pipeline_spec(TEST_PIPELINE_SPEC)
     check_pipeline_spec(req)


### PR DESCRIPTION
#293 
- `put_files` checks if source_path is individual file; uploads if it is file
- `put_files` checks if source_path is directory; uploads files recursively if it is directory
- otherwise throws an error
- added test case