### PR TITLE
Backport circleci config to v6.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+jobs:
+  tox:
+    resource_class: large
+    parameters:
+      toxenv:
+        type: string
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - run: 
+          name: Install dependencies
+          command: etc/testing/circle/install.sh
+      - when:
+          condition: 
+            not:
+              equal: [ lint, <<parameters.toxenv>> ] 
+          steps:
+            - run: 
+                name: Start minikube
+                command: etc/testing/circle/start-minikube.sh
+            - run:
+                name: Deploy pachyderm
+                command: etc/testing/circle/deploy-pachyderm.sh 
+      - run: 
+          name: TOXENV=<<parameters.toxenv>> tox
+          command: |
+            pachctl port-forward & 
+            python3 -m tox
+          environment:
+            TOXENV: << parameters.toxenv >>
+      - run:
+          when: on_fail
+          command: etc/testing/circle/kube_debug.sh
+
+workflows:
+  circleci:
+    jobs:
+      - tox:
+          matrix:
+            parameters:
+              toxenv:
+              - py36
+              - py39
+              - lint
+              - examples

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ src/python_pachyderm/version.py
 
 # virtualenv
 venv
+.python-version

--- a/etc/testing/circle/deploy-pachyderm.sh
+++ b/etc/testing/circle/deploy-pachyderm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+
+echo 'y' | pachctl deploy local
+kubectl wait --for=condition=available deployment -l app=pachd --timeout=5m
+pachctl version
+
+pachctl config update context "$(pachctl config get active-context)" --pachd-address="$(minikube ip):30650"

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p cached-deps
+
+sudo add-apt-repository ppa:deadsnakes/ppa
+
+# Install deps
+sudo apt update -y
+sudo apt-get install -y -qq \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  pkg-config \
+  conntrack \
+  pv \
+  jq \
+  socat \
+  python3.6 \
+  python3.9
+
+# Install kubectl
+# To get the latest kubectl version:
+# curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+if [ ! -f cached-deps/kubectl ] ; then
+    KUBECTL_VERSION="v$(jq -r .kubernetes version.json)"
+    curl -L -o kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+        chmod +x ./kubectl
+        mv ./kubectl cached-deps/kubectl
+fi
+
+# Install minikube
+# To get the latest minikube version:
+# curl https://api.github.com/repos/kubernetes/minikube/releases | jq -r .[].tag_name | sort -V | tail -n1
+if [ ! -f cached-deps/minikube ] ; then
+    MINIKUBE_VERSION="v$(jq -r .minikube version.json)"
+    curl -L -o minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && \
+        chmod +x ./minikube
+        mv ./minikube cached-deps/minikube
+fi
+
+export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
+
+# Install Pachyderm
+curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
+sudo dpkg -i /tmp/pachctl.deb
+
+# Install tox
+pip3 install tox

--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+echo "=== TEST FAILED OR TIMED OUT, DUMPING DEBUG INFO ==="
+
+export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+
+# TODO: Extend this to show kubectl describe output for failed pods, this will
+# probably show why things are hanging.
+
+# SC2016 blocks variables in single-quoted strings, but these are 'eval'ed below
+# shellcheck disable=SC2016
+cmds=(
+  'pachctl version'
+  'pachctl list repo'
+  'pachctl list repo --raw | jq -r ".repo.name" | while read r; do
+     echo "---";
+     pachctl inspect repo "${r}";
+     echo "Commits:";
+     pachctl list commit "${r}";
+     echo;
+   done'
+  'pachctl list pipeline'
+  'pachctl list job'
+  'kubectl version'
+  'kubectl get all --all-namespaces'
+  'kubectl describe pod -l suite=pachyderm,app=pachd'
+  'kubectl describe pod -l suite=pachyderm,app=etcd'
+  # Set --tail b/c by default 'kubectl logs' only outputs 10 lines if -l is set
+  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd'
+  'kubectl logs --tail=1500 -l suite=pachyderm,app=pachd --previous # if pachd restarted'
+  'sudo dmesg | tail -n 40'
+  'minikube logs | tail -n 100'
+  'top -b -n 1 | head -n 40'
+  'df -h'
+)
+for c in "${cmds[@]}"; do
+  echo "======================================================================"
+  echo "${c}"
+  echo "----------------------------------------------------------------------"
+  eval "${c}"
+done
+echo "======================================================================"

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -5,15 +5,15 @@ set -ex
 export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
 
 # Parse flags
-VERSION=v1.19.0
+KUBE_VERSION="$( jq -r .kubernetes <"$(git rev-parse --show-toplevel)/version.json" )"
 minikube_args=(
   "--vm-driver=docker"
-  "--kubernetes-version=${VERSION}"
+  "--kubernetes-version=${KUBE_VERSION}"
 )
 while getopts ":v" opt; do
   case "${opt}" in
     v)
-      VERSION="v${OPTARG}"
+      KUBE_VERSION="v${OPTARG}"
       ;;
     \?)
       echo "Invalid argument: ${opt}"
@@ -21,10 +21,6 @@ while getopts ":v" opt; do
       ;;
   esac
 done
-
-if [[ -n "${TRAVIS}" ]]; then
-  minikube_args+=("--bootstrapper=kubeadm")
-fi
 
 minikube start "${minikube_args[@]}"
 

--- a/etc/testing/circle/start-minikube.sh
+++ b/etc/testing/circle/start-minikube.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
+
+# Parse flags
+VERSION=v1.19.0
+minikube_args=(
+  "--vm-driver=docker"
+  "--kubernetes-version=${VERSION}"
+)
+while getopts ":v" opt; do
+  case "${opt}" in
+    v)
+      VERSION="v${OPTARG}"
+      ;;
+    \?)
+      echo "Invalid argument: ${opt}"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "${TRAVIS}" ]]; then
+  minikube_args+=("--bootstrapper=kubeadm")
+fi
+
+minikube start "${minikube_args[@]}"
+
+# Try to connect for three minutes
+for _ in $(seq 36); do
+  if kubectl version &>/dev/null; then
+    exit 0
+  fi
+  sleep 5
+done
+
+# Give up--kubernetes isn't coming up
+minikube delete
+sleep 30 # Wait for minikube to go completely down
+exit 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py35, py38, lint, examples
+envlist = py36, py39, lint, examples
 
 [travis]
 python =
-    3.8: py38
-    3.5: py35
+    3.6: py36
+    3.9: py39
 
 [testenv]
 setenv =

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "pachyderm": "1.13.2",
+    "pachyderm": "1.13.3",
     "python-pachyderm": "6.2.0",
     "kubernetes": "1.21.1",
     "minikube": "1.20.0"


### PR DESCRIPTION
This is just cherry-picking the change from #301 to the v6.x branch. It only runs against the version of pachyderm in version.json (1.13.2), but we could adapt it to do multiple pach versions instead.