### PR TITLE
Revert list_pipeline and inspect_pipeline

### DIFF
--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -134,10 +134,10 @@ def test_datums():
 
 def test_inspect_pipeline():
     sandbox = Sandbox("inspect_pipeline")
-    pipeline = sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name)
+    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
     assert pipeline.pipeline.name == sandbox.pipeline_repo_name
     pipelines = list(
-        sandbox.client.list_pipeline(sandbox.pipeline_repo_name, history=-1)
+        sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name, history=-1)
     )
     assert sandbox.pipeline_repo_name in [p.pipeline.name for p in pipelines]
 
@@ -168,11 +168,11 @@ def test_restart_pipeline():
     sandbox = Sandbox("restart_job")
 
     sandbox.client.stop_pipeline(sandbox.pipeline_repo_name)
-    pipeline = sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name)
+    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
     assert pipeline.stopped
 
     sandbox.client.start_pipeline(sandbox.pipeline_repo_name)
-    pipeline = sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name)
+    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
     assert not pipeline.stopped
 
 


### PR DESCRIPTION
Closes #314 

Reverted `list_pipeline()` and `inspect_pipeline()` to what they were before. It's confusing for `list_pipeline()` to take an arg for `pipeline_name` since the point of the function is to list pipelines. The reason why the RPC is designed to take that arg is so it can stream historical versions for a specific pipeline, which makes more sense in `inspect_pipeline()`.

Context: https://pachyderm.slack.com/archives/C0163RX3YQZ/p1629220407011900?thread_ts=1629219945.011600&cid=C0163RX3YQZ