### PR TITLE
Remove returns from methods whose RPC calls return a negligible protobuf

### DIFF
--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -21,7 +21,7 @@ class AuthMixin:
         Deactivates auth, removing all ACLs, tokens, and admins from the
         Pachyderm cluster and making all data publicly accessible.
         """
-        return self._req(Service.AUTH, "Deactivate")
+        self._req(Service.AUTH, "Deactivate")
 
     def get_auth_configuration(self):
         """
@@ -37,7 +37,7 @@ class AuthMixin:
 
         * `config`: An `AuthConfig` object.
         """
-        return self._req(Service.AUTH, "SetConfiguration", configuration=configuration)
+        self._req(Service.AUTH, "SetConfiguration", configuration=configuration)
 
     def get_role_binding(self, resource):
         """
@@ -55,7 +55,7 @@ class AuthMixin:
         * `principal`: A string specifying the principal.
         * `roles`: A list of roles to grant. If empty, all roles are revoked.
         """
-        return self._req(
+        self._req(
             Service.AUTH,
             "ModifyRoleBinding",
             resource=resource,
@@ -143,7 +143,7 @@ class AuthMixin:
         * `token`: A string that indicates the Pachyderm token that is being
         revoked.
         """
-        return self._req(Service.AUTH, "RevokeAuthToken", token=token)
+        self._req(Service.AUTH, "RevokeAuthToken", token=token)
 
     def set_groups_for_user(self, username, groups):
         """
@@ -154,9 +154,7 @@ class AuthMixin:
         * `username`: A string.
         * `groups`: A list of strings.
         """
-        return self._req(
-            Service.AUTH, "SetGroupsForUser", username=username, groups=groups
-        )
+        self._req(Service.AUTH, "SetGroupsForUser", username=username, groups=groups)
 
     def modify_members(self, group, add=None, remove=None):
         """
@@ -168,7 +166,7 @@ class AuthMixin:
         * `add`: An optional list of strings specifying members to add.
         * `remove`: An optional list of strings specifying members to remove.
         """
-        return self._req(
+        self._req(
             Service.AUTH,
             "ModifyMembers",
             group=group,

--- a/src/python_pachyderm/mixin/enterprise.py
+++ b/src/python_pachyderm/mixin/enterprise.py
@@ -13,7 +13,7 @@ class EnterpriseMixin:
         * `id`: The unique ID for this cluster.
         * `secret`: The secret for registering this cluster.
         """
-        return self._req(
+        self._req(
             Service.ENTERPRISE,
             "Activate",
             license_server=license_server,
@@ -30,7 +30,7 @@ class EnterpriseMixin:
 
     def deactivate_enterprise(self):
         """Deactivates enterprise."""
-        return self._req(Service.ENTERPRISE, "Deactivate")
+        self._req(Service.ENTERPRISE, "Deactivate")
 
     def get_activation_code(self):
         """

--- a/src/python_pachyderm/mixin/identity.py
+++ b/src/python_pachyderm/mixin/identity.py
@@ -10,7 +10,7 @@ class IdentityMixin:
 
         * `issuer`: The issuer for the identity server.
         """
-        return self._req(Service.IDENTITY, "SetIdentityServerConfig", config=config)
+        self._req(Service.IDENTITY, "SetIdentityServerConfig", config=config)
 
     def get_identity_server_config(self):
         """
@@ -22,7 +22,7 @@ class IdentityMixin:
         """
         Create an IDP connector in the identity server.
         """
-        return self._req(Service.IDENTITY, "CreateIDPConnector", connector=connector)
+        self._req(Service.IDENTITY, "CreateIDPConnector", connector=connector)
 
     def list_idp_connectors(self):
         """
@@ -34,7 +34,7 @@ class IdentityMixin:
         """
         Update an IDP connector in the identity server.
         """
-        return self._req(Service.IDENTITY, "UpdateIDPConnector", connector=connector)
+        self._req(Service.IDENTITY, "UpdateIDPConnector", connector=connector)
 
     def get_idp_connector(self, id):
         """
@@ -46,7 +46,7 @@ class IdentityMixin:
         """
         Delete an IDP connector in the identity server.
         """
-        return self._req(Service.IDENTITY, "DeleteIDPConnector", id=id)
+        self._req(Service.IDENTITY, "DeleteIDPConnector", id=id)
 
     def create_oidc_client(self, client):
         """
@@ -70,7 +70,7 @@ class IdentityMixin:
         """
         Delete an OIDC client in the identity server.
         """
-        return self._req(Service.IDENTITY, "DeleteOIDCClient", id=id)
+        self._req(Service.IDENTITY, "DeleteOIDCClient", id=id)
 
     def list_oidc_clients(self):
         """
@@ -82,4 +82,4 @@ class IdentityMixin:
         """
         Delete all identity service information.
         """
-        return self._req(Service.IDENTITY, "DeleteAll")
+        self._req(Service.IDENTITY, "DeleteAll")

--- a/src/python_pachyderm/mixin/license.py
+++ b/src/python_pachyderm/mixin/license.py
@@ -64,7 +64,7 @@ class LicenseMixin:
         * `id`: The unique ID to identify the cluster.
         * `address`: A GRPC address for the license server to reach the cluster.
         """
-        return self._req(
+        self._req(
             Service.LICENSE,
             "UpdateCluster",
             id=id,
@@ -81,7 +81,7 @@ class LicenseMixin:
 
         * `id`: The unique ID to identify the cluster.
         """
-        return self._req(Service.LICENSE, "DeleteCluster", id=id)
+        self._req(Service.LICENSE, "DeleteCluster", id=id)
 
     def list_clusters(self):
         """
@@ -99,7 +99,7 @@ class LicenseMixin:
         """
         Remove all clusters and deactivate the license service.
         """
-        return self._req(Service.LICENSE, "DeleteAll")
+        self._req(Service.LICENSE, "DeleteAll")
 
     def list_user_clusters(self):
         """

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -112,7 +112,7 @@ class PFSMixin:
         * `description`: An optional string describing the repo.
         * `update`: Whether to update if the repo already exists.
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "CreateRepo",
             repo=pfs_proto.Repo(name=repo_name, type="user"),
@@ -153,7 +153,7 @@ class PFSMixin:
         * `force`: If set to true, the repo will be removed regardless of
           errors. This argument should be used with care.
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "DeleteRepo",
             repo=pfs_proto.Repo(name=repo_name, type="user"),
@@ -164,7 +164,7 @@ class PFSMixin:
         """
         Deletes all repos.
         """
-        return self._req(Service.PFS, "DeleteAll", req=empty_pb2.Empty())
+        self._req(Service.PFS, "DeleteAll", req=empty_pb2.Empty())
 
     def start_commit(self, repo_name, branch, parent=None, description=None) -> Commit:
         """
@@ -222,7 +222,7 @@ class PFSMixin:
         * `force`: An optional bool. If true, commit will be forcefully
         finished, even if it breaks provenance.
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "FinishCommit",
             commit=commit_from(commit),
@@ -349,7 +349,7 @@ class PFSMixin:
         Params:
         * `commit_id`: the id of a `Commit`.
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "SquashCommitSet",
             commit_set=pfs_proto.CommitSet(id=commit_id),
@@ -424,7 +424,7 @@ class PFSMixin:
         * `new_commitset`: A bool, overrides the default behavior of using the
            same Commitset as 'head'
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "CreateBranch",
             branch=pfs_proto.Branch(
@@ -477,7 +477,7 @@ class PFSMixin:
         * `branch_name`: A string specifying the name of the branch to delete.
         * `force`: A bool specifying whether to force the branch deletion.
         """
-        return self._req(
+        self._req(
             Service.PFS,
             "DeleteBranch",
             branch=pfs_proto.Branch(
@@ -523,14 +523,14 @@ class PFSMixin:
         """
         with self.modify_file_client(commit) as pfc:
             if hasattr(value, "read"):
-                return pfc.put_file_from_fileobj(
+                pfc.put_file_from_fileobj(
                     path,
                     value,
                     tag=tag,
                     append=append,
                 )
             else:
-                return pfc.put_file_from_bytes(
+                pfc.put_file_from_bytes(
                     path,
                     value,
                     tag=tag,
@@ -719,7 +719,7 @@ class PFSMixin:
         * `path`: The path to the file.
         """
         with self.modify_file_client(commit) as pfc:
-            return pfc.delete_file(path)
+            pfc.delete_file(path)
 
     def fsck(self, fix=None):
         """

--- a/src/python_pachyderm/mixin/pps.py
+++ b/src/python_pachyderm/mixin/pps.py
@@ -110,7 +110,7 @@ class PPSMixin:
         * `job_id`: The ID of the job to delete.
         * `pipeline_name`: A string representing the pipeline name.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "DeleteJob",
             job=pps_proto.Job(
@@ -127,7 +127,7 @@ class PPSMixin:
         * `pipeline_name`: A string representing the pipeline name.
         * `reason`: a str specifying the reason for stopping the job.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "StopJob",
             job=pps_proto.Job(
@@ -188,7 +188,7 @@ class PPSMixin:
         * `job_id`: The ID of the job.
         * `data_filters`: An optional iterable of strings.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "RestartDatum",
             job=pps_proto.Job(
@@ -266,7 +266,7 @@ class PPSMixin:
         resource limits for the pipeline sidecar.
         """
 
-        return self._req(
+        self._req(
             Service.PPS,
             "CreatePipeline",
             pipeline=pps_proto.Pipeline(name=pipeline_name),
@@ -309,7 +309,7 @@ class PPSMixin:
 
         * `req`: A `CreatePipelineRequest` object.
         """
-        return self._req(Service.PPS, "CreatePipeline", req=req)
+        self._req(Service.PPS, "CreatePipeline", req=req)
 
     def inspect_pipeline(self, pipeline_name, history=None, details=None):
         """
@@ -386,7 +386,7 @@ class PPSMixin:
         * `force`: Whether to force delete.
         * `keep_repo`: Whether to keep the repo.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "DeletePipeline",
             pipeline=pps_proto.Pipeline(name=pipeline_name),
@@ -398,7 +398,7 @@ class PPSMixin:
         """
         Deletes all pipelines in pachyderm.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "DeleteAll",
             req=empty_pb2.Empty(),
@@ -412,7 +412,7 @@ class PPSMixin:
 
         * `pipeline_name`: A string representing the pipeline name.
         """
-        return self._req(
+        self._req(
             Service.PPS,
             "StartPipeline",
             pipeline=pps_proto.Pipeline(name=pipeline_name),
@@ -426,7 +426,7 @@ class PPSMixin:
 
         * `pipeline_name`: A string representing the pipeline name.
         """
-        return self._req(
+        self._req(
             Service.PPS, "StopPipeline", pipeline=pps_proto.Pipeline(name=pipeline_name)
         )
 
@@ -440,7 +440,7 @@ class PPSMixin:
         * `pipeline_name`: A string representing the pipeline name.
         """
 
-        return self._req(
+        self._req(
             Service.PPS,
             "RunCron",
             pipeline=pps_proto.Pipeline(name=pipeline_name),
@@ -481,7 +481,7 @@ class PPSMixin:
             }
         ).encode("utf8")
 
-        return self._req(Service.PPS, "CreateSecret", file=f)
+        self._req(Service.PPS, "CreateSecret", file=f)
 
     def delete_secret(self, secret_name):
         """
@@ -492,7 +492,7 @@ class PPSMixin:
         * `secret_name`: The name of the secret to delete.
         """
         secret = pps_proto.Secret(name=secret_name)
-        return self._req(Service.PPS, "DeleteSecret", secret=secret)
+        self._req(Service.PPS, "DeleteSecret", secret=secret)
 
     def list_secret(self):
         """

--- a/src/python_pachyderm/mixin/transaction.py
+++ b/src/python_pachyderm/mixin/transaction.py
@@ -50,7 +50,7 @@ class TransactionMixin:
 
         * `transaction`: A string or `Transaction` object.
         """
-        return self._req(
+        self._req(
             Service.TRANSACTION,
             "DeleteTransaction",
             transaction=transaction_from(transaction),
@@ -60,7 +60,7 @@ class TransactionMixin:
         """
         Deletes all transactions.
         """
-        return self._req(Service.TRANSACTION, "DeleteAll")
+        self._req(Service.TRANSACTION, "DeleteAll")
 
     def list_transaction(self):
         """


### PR DESCRIPTION
Negligible protobufs being either Empty protobuf or one of our own protobufs that have no fields.