### PR TITLE
checking for diff in config file

### DIFF
--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -10,7 +10,7 @@ export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH
 # SC2016 blocks variables in single-quoted strings, but these are 'eval'ed below
 # shellcheck disable=SC2016
 cmds=(
-  'rm ~/.pachyderm/config.json'
+  #'rm ~/.pachyderm/config.json'
   'pachctl version'
   'pachctl list repo'
   'pachctl list repo --raw | jq -r ".repo.name" | while read r; do


### PR DESCRIPTION
This PR is being used to investigate why removing the config file in CircleCI allows pachctl commands to not hang, allowing the kube_debug script to run properly.