### PR TITLE
Revert "Update 7.0.x to use pach 2.0.2 protos"

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-    "pachyderm": "2.0.2",
-    "python-pachyderm": "7.0.1",
+    "pachyderm": "2.0.0",
+    "python-pachyderm": "7.0.0",
     "kubernetes": "1.21.0",
     "minikube": "1.22.0"
 }


### PR DESCRIPTION
Reverts pachyderm/python-pachyderm#363

@smalyala and I decided that these changes should go out in a minor release, rather than a patch release. This PR removes them from the `v7.0.x` branch, which should only contain patch-release-level changes to 7.0.0.