### PR TITLE
Update version.json & 'make release' versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ init:
 	pre-commit install
 
 release:
-	git checkout <branch>
+	git checkout origin/v7.1.x
 	rm -rf build dist
 	python3 setup.py sdist
 	twine upload dist/*
 
 test-release:
-	git checkout <branch>
+	git checkout origin/v7.1.x
 	rm -rf build dist
 	sed -i "" 's/name="python-pachyderm"/name="python-pachyderm-test"/g' setup.py
 	python3 setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setup(
             "Sphinx==4.3.0",
             "sphinx-rtd-theme==1.0.0",
             "myst-parser==0.15.2",
+            # releasing
+            "twine==3.6.0",
         ],
         "test": [
             "pytest==5.3.4",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "pachyderm": "2.0.2",
-    "python-pachyderm": "7.1.0",
+    "python-pachyderm": "7.1.1",
     "kubernetes": "1.21.0",
     "minikube": "1.22.0"
 }


### PR DESCRIPTION
- Update `version.json` to indicate the release currently in development on the `v7.1.x` branch (which is 7.1.1)
- Update `make release` to check out the right branch
- Add `twine` to our DEV deps in setup.py