### PR TITLE
Update release instructions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -130,8 +130,11 @@ Our current process for publishing a release of python-pachyderm consists of the
   - [ ] [Pachyderm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101), which should match `examples/spouts101` in this repo, but it's good to confirm
 - [ ] Rebuild docs to make sure they're in sync, and push the updated docs
 - [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version). Commit and push this change to `master`
-- [ ] Edit the `make release` rule in `Makefile` so that it references the release branch (currently it's hard-coded to `master`)
-- [ ] Run `make release`, which will pull `master` (or whatever branch you configured in the previous step), build a package, and push it to pypi
-- [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the commit from three steps ago (the one that incremented `version.json`
-- [ ] (Major releases only) Create a new branch for the new release. For example, if releasing 7.0.0, create a new `7.x` branch to hold future changes to the 7.x release line (master now contains the future contents of 8.x)
+- [ ] Push to pypi
+  - [ ] Edit both the `make test-release` and `make release` rules in `Makefile`, so that they reference the release branch (currently it's hard-coded to `master`)
+  - [ ] Run `make test-release`, which will pull `master` (or whatever branch you used in the previous step), build a package, and push it to test-pypi. Confirm that it looks good, as pypi doesn't allow you to modify a release after pushing it.
+  - [ ] Run `make release`, which will pull `master` (or whatever branch you used above), build a package, and push it to test-pypi. Confirm that it looks good, as pypi doesn't allow you to modify a release after pushing it.
+- [ ] Make the GitHub release
+  - [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the commit from above (the one that incremented `version.json`)
+  - [ ] (Major releases only) Create a new branch for the new release. For example, if releasing 7.0.0, create a new `7.x` branch to hold future changes to the 7.x release line (master now contains the future contents of 8.x)
 To make a new release, from the master branch:

--- a/contributing.md
+++ b/contributing.md
@@ -131,7 +131,7 @@ Our current process for publishing a release of python-pachyderm consists of the
 - [ ] Ensure the docs are up-to-date
   - Rebuild the docs (with `make docs`), and make sure the generated docs are unchanged
   - Merge any changes in a PR
-- [ ] Ensure the changelog is up-to-date
+- [ ] Ensure `CHANGELOG.md` is up-to-date
   - Commit any additional change notes in a PR.
 
 #### Test everything
@@ -150,6 +150,7 @@ This is mostly necessary for major releases, but it always reduces risk.
 
 #### Make GitHub release
   - [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the Git commit that was just pushed to pypi
+    - Include any notes added to `CHANGELOG.md` for this release
   - [ ] &#40;Only when releasing from `master`&#41; Create a new branch for patch releases called `vA.B.x`. For example, if releasing 1.0.0, create a new `v1.0.x` branch to hold future patch-sized changes made to 1.0.0.
 
 #### Update versions for next release

--- a/contributing.md
+++ b/contributing.md
@@ -126,8 +126,8 @@ Our current process for publishing a release of python-pachyderm consists of the
   - [ ] Run `make src/python_pachyderm/proto/v2` to pull the latest pachyderm code
   - [ ] Run `make lint` and our test suite (see `contributing.md`)
 - [ ] Ensure that all examples still pass:
-  - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`
-  - [ ] [Pachyerm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101) (should match `examples/spouts101` in this repo, but it's good to confirm
+  - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`)
+  - [ ] [Pachyderm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101), which should match `examples/spouts101` in this repo, but it's good to confirm
 - [ ] Rebuild docs to make sure they're in sync, and push the updated docs
 - [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version). Commit and push this change to `master`
 - [ ] Edit the `make release` rule in `Makefile` so that it references the release branch (currently it's hard-coded to `master`)

--- a/contributing.md
+++ b/contributing.md
@@ -124,17 +124,17 @@ Our current process for publishing a release of python-pachyderm consists of the
 - [ ] Ensure compatibility with the latest protos:
   - [ ] Make sure `version.json` references the most recent compatible release of Pachyderm
   - [ ] Run `make src/python_pachyderm/proto/v2` to pull the latest pachyderm code
-  - [ ] Run `make lint` and our test suite (see `contributing.md`)
+  - [ ] Run `make lint`
+  - [ ] Deploy the version of pachyderm (and retrieve the version of `pachctl`) that matches `version.json` (the latest compatible release) and run out test suite (see above)
 - [ ] Ensure that all examples still pass:
   - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`)
   - [ ] [Pachyderm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101), which should match `examples/spouts101` in this repo, but it's good to confirm
 - [ ] Rebuild docs to make sure they're in sync, and push the updated docs
-- [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version). Commit and push this change to `master`
-- [ ] Push to pypi
+- [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version) and update the changelog. Commit this change and push it to `master`
+- [ ] Push to pypi:
   - [ ] Edit both the `make test-release` and `make release` rules in `Makefile`, so that they reference the release branch (currently it's hard-coded to `master`)
-  - [ ] Run `make test-release`, which will pull `master` (or whatever branch you used in the previous step), build a package, and push it to test-pypi. Confirm that it looks good, as pypi doesn't allow you to modify a release after pushing it.
+  - [ ] Run `make test-release`, which will pull `master` (or whatever branch you used in the previous step), build a package, and push it to test-pypi. Proofread the release page, as pypi doesn't allow you to modify a release after pushing it.
   - [ ] Run `make release`, which will pull `master` (or whatever branch you used above), build a package, and push it to test-pypi. Confirm that it looks good, as pypi doesn't allow you to modify a release after pushing it.
-- [ ] Make the GitHub release
+- [ ] Make the GitHub release:
   - [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the commit from above (the one that incremented `version.json`)
   - [ ] (Major releases only) Create a new branch for the new release. For example, if releasing 7.0.0, create a new `7.x` branch to hold future changes to the 7.x release line (master now contains the future contents of 8.x)
-To make a new release, from the master branch:

--- a/contributing.md
+++ b/contributing.md
@@ -119,11 +119,19 @@ make docs
 
 ## Releasing
 
+Our current process for publishing a release of python-pachyderm consists of the following steps:
+
+- [ ] Ensure compatibility with the latest protos:
+  - [ ] Make sure `version.json` references the most recent compatible release of Pachyderm
+  - [ ] Run `make src/python_pachyderm/proto/v2` to pull the latest pachyderm code
+  - [ ] Run `make lint` and our test suite (see `contributing.md`)
+- [ ] Ensure that all examples still pass:
+  - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`
+  - [ ] [Pachyerm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101) (should match `examples/spouts101` in this repo, but it's good to confirm
+- [ ] Rebuild docs to make sure they're in sync, and push the updated docs
+- [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version). Commit and push this change to `master`
+- [ ] Edit the `make release` rule in `Makefile` so that it references the release branch (currently it's hard-coded to `master`)
+- [ ] Run `make release`, which will pull `master` (or whatever branch you configured in the previous step), build a package, and push it to pypi
+- [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the commit from three steps ago (the one that incremented `version.json`
+- [ ] (Major releases only) Create a new branch for the new release. For example, if releasing 7.0.0, create a new `7.x` branch to hold future changes to the 7.x release line (master now contains the future contents of 8.x)
 To make a new release, from the master branch:
-
-* Rebuild docs to make sure they're in sync
-* Update `CHANGELOG.md` and `version.json`
-
-```bash
-make release
-```

--- a/contributing.md
+++ b/contributing.md
@@ -121,20 +121,40 @@ make docs
 
 Our current process for publishing a release of python-pachyderm consists of the following steps:
 
-- [ ] Ensure compatibility with the latest protos:
-  - [ ] Make sure `version.json` references the most recent compatible release of Pachyderm
-  - [ ] Run `make src/python_pachyderm/proto/v2` to pull the latest pachyderm code
-  - [ ] Run `make lint`
-  - [ ] Deploy the version of pachyderm (and retrieve the version of `pachctl`) that matches `version.json` (the latest compatible release) and run out test suite (see above)
-- [ ] Ensure that all examples still pass:
-  - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`)
-  - [ ] [Pachyderm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101), which should match `examples/spouts101` in this repo, but it's good to confirm
-- [ ] Rebuild docs to make sure they're in sync, and push the updated docs
-- [ ] Update `version.json` to the next version of `python-pachyderm` (this will be the released version) and update the changelog. Commit this change and push it to `master`
-- [ ] Push to pypi:
-  - [ ] Edit both the `make test-release` and `make release` rules in `Makefile`, so that they reference the release branch (currently it's hard-coded to `master`)
-  - [ ] Run `make test-release`, which will pull `master` (or whatever branch you used in the previous step), build a package, and push it to test-pypi. Proofread the release page, as pypi doesn't allow you to modify a release after pushing it.
-  - [ ] Run `make release`, which will pull `master` (or whatever branch you used above), build a package, and push it to test-pypi. Confirm that it looks good, as pypi doesn't allow you to modify a release after pushing it.
-- [ ] Make the GitHub release:
-  - [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the commit from above (the one that incremented `version.json`)
-  - [ ] (Major releases only) Create a new branch for the new release. For example, if releasing 7.0.0, create a new `7.x` branch to hold future changes to the 7.x release line (master now contains the future contents of 8.x)
+#### Validate the release
+- [ ] Ensure that `version.json` contains the `python-pachyderm` version to be released
+  - If `version.json` contains an already-released version of python-pachyderm, update it in a PR.
+- [ ] Ensure the protobufs are up-to-date
+  - Make sure `version.json` references the most recent compatible release of Pachyderm
+  - Run `make src/python_pachyderm/proto/v2`, and make sure that the generated code is unchanged
+  - If it's outdated, update it in a PR
+- [ ] Ensure the docs are up-to-date
+  - Rebuild the docs (with `make docs`), and make sure the generated docs are unchanged
+  - Merge any changes in a PR
+- [ ] Ensure the changelog is up-to-date
+  - Commit any additional change notes in a PR.
+
+#### Test everything
+This is mostly necessary for major releases, but it always reduces risk.
+  - [ ] Deploy the version of pachyderm that matches `version.json` (the latest compatible release) and run our test suite.
+    - Make sure to install a matching version of `pachctl`, as e.g. python-pachyderm's `Mount()` implementation depends on `pachctl`
+  - [ ] Run `make lint` and ensure there are no errors
+  - [ ] Ensure that all examples still pass:
+    - [ ] All examples in the `examples/` dir (they must be run manually—`tox example` only runs `examples/opencv`)
+    - [ ] [Pachyderm's spouts101 example](github.com/pachyderm/pachyderm/tree/master/examples/spouts101), which should match `examples/spouts101` in this repo, but it's good to confirm
+
+#### Make Pypi release
+  - [ ] Run `make test-release`, which will checkout the release branch, build a package, and push it to test-pypi.
+    - Proofread the release page, as pypi doesn't allow you to modify a release after pushing it.
+  - [ ] Run `make release` which will re-build python-pachyderm and push a final version to pypi.
+
+#### Make GitHub release
+  - [ ] Go to http://github.com/pachyderm/python-pachyderm and create a new GitHub release pointing at the Git commit that was just pushed to pypi
+  - [ ] &#40;Only when releasing from `master`&#41; Create a new branch for patch releases called `vA.B.x`. For example, if releasing 1.0.0, create a new `v1.0.x` branch to hold future patch-sized changes made to 1.0.0.
+
+#### Update versions for next release
+  - [ ] In the patch release branch (e.g. `v1.0.x`), create a PR to update the python-pachyderm version in `version.json` to contain the next _patch_ release (e.g. 1.0.1)
+    - This is the python-pachyderm version that is currently in development in that branch.
+  - [ ] &#40;Only when releasing from `master`&#41; In `master`, create a PR to update the python-pachyderm version in `version.json` to contain the next _minor_ release (e.g. 1.1.0)
+    - This is the python-pachyderm version that is currently in development in `master`.
+  - [ ] &#40;Only when releasing from `master`&#41; In the new patch release branch (e.g. `v1.0.x`), create a PR (or add to the above PR) to update `make release` so that it checks out `v1.0.x` instead of `master` when releasing from this branch.

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setup(
             "Sphinx==4.3.0",
             "sphinx-rtd-theme==1.0.0",
             "myst-parser==0.15.2",
+            # releasing
+            "twine==3.6.0",
         ],
         "test": [
             "pytest==5.3.4",


### PR DESCRIPTION
- This is essentially #330 for the `v7.0.x` branch
- Also add `twine` (release tool) to the DEV deps in `setup.py`