### PR TITLE
[WIP] Refactor gRPC method infrastructure

### DIFF
--- a/src/python_pachyderm/mixin/admin.py
+++ b/src/python_pachyderm/mixin/admin.py
@@ -1,11 +1,21 @@
-from python_pachyderm.service import Service, admin_proto
+from typing import List, Tuple
+
+import grpc
 from google.protobuf import empty_pb2
+
+from python_pachyderm.proto.v2.admin import admin_pb2, admin_pb2_grpc
 
 
 class AdminMixin:
     """A mixin for admin-related functionality."""
 
-    def inspect_cluster(self) -> admin_proto.ClusterInfo:
+    _channel: grpc.Channel
+    _metadata: List[Tuple[str, str]]
+
+    def __init__(self):
+        self.__stub = admin_pb2_grpc.APIStub(self._channel)
+
+    def inspect_cluster(self) -> admin_pb2.ClusterInfo:
         """Inspects a cluster.
 
         Returns
@@ -13,8 +23,5 @@ class AdminMixin:
         admin_proto.ClusterInfo
             A protobuf object with info on the cluster.
         """
-        return self._req(
-            Service.ADMIN,
-            "InspectCluster",
-            req=empty_pb2.Empty(),
-        )
+        message = empty_pb2.Empty()
+        return self.__stub.InspectCluster(message, metadata=self._metadata)

--- a/src/python_pachyderm/mixin/admin.py
+++ b/src/python_pachyderm/mixin/admin.py
@@ -14,6 +14,7 @@ class AdminMixin:
 
     def __init__(self):
         self.__stub = admin_pb2_grpc.APIStub(self._channel)
+        super().__init__()
 
     def inspect_cluster(self) -> admin_pb2.ClusterInfo:
         """Inspects a cluster.

--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -48,7 +48,9 @@ class AuthMixin:
             A protobuf object with auth configuration information.
         """
         message = auth_pb2.GetConfigurationRequest()
-        return self.__stub.GetConfiguration(message, metadata=self._metadata).configuration
+        return self.__stub.GetConfiguration(
+            message, metadata=self._metadata
+        ).configuration
 
     def set_auth_configuration(self, configuration: auth_pb2.OIDCConfig) -> None:
         """Sets the auth configuration.
@@ -70,7 +72,9 @@ class AuthMixin:
         message = auth_pb2.SetConfigurationRequest(configuration=configuration)
         self.__stub.SetConfiguration(message, metadata=self._metadata)
 
-    def get_role_binding(self, resource: auth_pb2.Resource) -> Dict[str, auth_pb2.Roles]:
+    def get_role_binding(
+        self, resource: auth_pb2.Resource
+    ) -> Dict[str, auth_pb2.Roles]:
         """Returns the current set of role bindings to the resource specified.
 
         Parameters
@@ -112,7 +116,9 @@ class AuthMixin:
         .. # noqa: W505
         """
         message = auth_pb2.GetRoleBindingRequest(resource=resource)
-        return self.__stub.GetRoleBinding(message, metadata=self._metadata).binding_entries
+        return self.__stub.GetRoleBinding(
+            message, metadata=self._metadata
+        ).binding_entries
 
     def modify_role_binding(
         self, resource: auth_pb2.Resource, principal: str, roles: List[str] = None
@@ -146,7 +152,9 @@ class AuthMixin:
         ... )
         """
         message = auth_pb2.ModifyRoleBindingRequest(
-            resource=resource, principal=principal, roles=roles,
+            resource=resource,
+            principal=principal,
+            roles=roles,
         )
         self.__stub.ModifyRoleBinding(message, metadata=self._metadata)
 
@@ -198,7 +206,7 @@ class AuthMixin:
     def authorize(
         self,
         resource: auth_pb2.Resource,
-        permissions: List[auth_pb2.Permission] = None,
+        permissions: List["auth_pb2.Permission"] = None,
     ) -> auth_pb2.AuthorizeResponse:
         """Tests a list of permissions that the user might have on a resource.
 

--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -13,6 +13,7 @@ class AuthMixin:
 
     def __init__(self):
         self.__stub = auth_pb2_grpc.APIStub(self._channel)
+        super().__init__()
 
     def activate_auth(self, root_token: str = None) -> str:
         """Activates auth on the cluster. Returns the root token, an

--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -119,7 +119,7 @@ class AuthMixin:
         message = auth_pb2.GetRoleBindingRequest(resource=resource)
         return self.__stub.GetRoleBinding(
             message, metadata=self._metadata
-        ).binding_entries
+        ).binding.entries
 
     def modify_role_binding(
         self, resource: auth_pb2.Resource, principal: str, roles: List[str] = None

--- a/src/python_pachyderm/mixin/auth.py
+++ b/src/python_pachyderm/mixin/auth.py
@@ -1,9 +1,18 @@
-from typing import Dict, List
-from python_pachyderm.service import Service, auth_proto
+from typing import Dict, List, Tuple
+
+import grpc
+
+from python_pachyderm.proto.v2.auth import auth_pb2, auth_pb2_grpc
 
 
 class AuthMixin:
     """A mixin for auth-related functionality."""
+
+    _channel: grpc.Channel
+    _metadata: List[Tuple[str, str]]
+
+    def __init__(self):
+        self.__stub = auth_pb2_grpc.APIStub(self._channel)
 
     def activate_auth(self, root_token: str = None) -> str:
         """Activates auth on the cluster. Returns the root token, an
@@ -20,15 +29,17 @@ class AuthMixin:
         str
             A token used as the root user login token.
         """
-        return self._req(Service.AUTH, "Activate", root_token=root_token).pach_token
+        message = auth_pb2.ActivateRequest(root_token=root_token)
+        return self.__stub.Activate(message, metadata=self._metadata).pach_token
 
     def deactivate_auth(self) -> None:
         """Deactivates auth, removing all ACLs, tokens, and admins from the
         Pachyderm cluster and making all data publicly accessible.
         """
-        self._req(Service.AUTH, "Deactivate")
+        message = auth_pb2.DeactivateRequest()
+        self.__stub.Deactivate(message, metadata=self._metadata)
 
-    def get_auth_configuration(self) -> auth_proto.OIDCConfig:
+    def get_auth_configuration(self) -> auth_pb2.OIDCConfig:
         """Gets the auth configuration.
 
         Returns
@@ -36,9 +47,10 @@ class AuthMixin:
         auth_proto.OIDCConfig
             A protobuf object with auth configuration information.
         """
-        return self._req(Service.AUTH, "GetConfiguration").configuration
+        message = auth_pb2.GetConfigurationRequest()
+        return self.__stub.GetConfiguration(message, metadata=self._metadata).configuration
 
-    def set_auth_configuration(self, configuration: auth_proto.OIDCConfig) -> None:
+    def set_auth_configuration(self, configuration: auth_pb2.OIDCConfig) -> None:
         """Sets the auth configuration.
 
         Parameters
@@ -55,11 +67,10 @@ class AuthMixin:
         ...     redirect_uri="http://test.example.com",
         ... ))
         """
-        self._req(Service.AUTH, "SetConfiguration", configuration=configuration)
+        message = auth_pb2.SetConfigurationRequest(configuration=configuration)
+        self.__stub.SetConfiguration(message, metadata=self._metadata)
 
-    def get_role_binding(
-        self, resource: auth_proto.Resource
-    ) -> Dict[str, auth_proto.Roles]:
+    def get_role_binding(self, resource: auth_pb2.Resource) -> Dict[str, auth_pb2.Roles]:
         """Returns the current set of role bindings to the resource specified.
 
         Parameters
@@ -100,12 +111,11 @@ class AuthMixin:
 
         .. # noqa: W505
         """
-        return self._req(
-            Service.AUTH, "GetRoleBinding", resource=resource
-        ).binding.entries
+        message = auth_pb2.GetRoleBindingRequest(resource=resource)
+        return self.__stub.GetRoleBinding(message, metadata=self._metadata).binding_entries
 
     def modify_role_binding(
-        self, resource: auth_proto.Resource, principal: str, roles: List[str] = None
+        self, resource: auth_pb2.Resource, principal: str, roles: List[str] = None
     ) -> None:
         """Sets the roles for a given principal on a resource.
 
@@ -135,15 +145,12 @@ class AuthMixin:
         ...     roles=["repoWriter"]
         ... )
         """
-        self._req(
-            Service.AUTH,
-            "ModifyRoleBinding",
-            resource=resource,
-            principal=principal,
-            roles=roles,
+        message = auth_pb2.ModifyRoleBindingRequest(
+            resource=resource, principal=principal, roles=roles,
         )
+        self.__stub.ModifyRoleBinding(message, metadata=self._metadata)
 
-    def get_oidc_login(self) -> auth_proto.GetOIDCLoginResponse:
+    def get_oidc_login(self) -> auth_pb2.GetOIDCLoginResponse:
         """Gets the OIDC login configuration.
 
         Returns
@@ -151,7 +158,8 @@ class AuthMixin:
         auth_proto.GetOIDCLoginResponse
             A protobuf object with the login configuration information.
         """
-        return self._req(Service.AUTH, "GetOIDCLogin")
+        message = auth_pb2.GetOIDCLoginRequest()
+        return self.__stub.GetOIDCLogin(message, metadata=self._metadata)
 
     def authenticate_oidc(self, oidc_state: str) -> str:
         """Authenticates a user to the Pachyderm cluster via OIDC.
@@ -166,7 +174,8 @@ class AuthMixin:
         str
             A token that can be used for making authenticate requests.
         """
-        return self._req(Service.AUTH, "Authenticate", oidc_state=oidc_state).pach_token
+        message = auth_pb2.AuthenticateRequest(oidc_state=oidc_state)
+        return self.__stub.Authorize(message, metadata=self._metadata).pach_token
 
     def authenticate_id_token(self, id_token: str) -> str:
         """Authenticates a user to the Pachyderm cluster using an ID token
@@ -183,13 +192,14 @@ class AuthMixin:
         str
             A token that can be used for making authenticate requests.
         """
-        return self._req(Service.AUTH, "Authenticate", id_token=id_token).pach_token
+        message = auth_pb2.AuthenticateRequest(id_token=id_token)
+        return self.__stub.Authorize(message, metadata=self._metadata).pach_token
 
     def authorize(
         self,
-        resource: auth_proto.Resource,
-        permissions: List["auth_proto.Permission"] = None,
-    ) -> auth_proto.AuthorizeResponse:
+        resource: auth_pb2.Resource,
+        permissions: List[auth_pb2.Permission] = None,
+    ) -> auth_pb2.AuthorizeResponse:
         """Tests a list of permissions that the user might have on a resource.
 
         Parameters
@@ -217,11 +227,10 @@ class AuthMixin:
         satisfied: REPO_READ
         principal: "pach:root"
         """
-        return self._req(
-            Service.AUTH, "Authorize", resource=resource, permissions=permissions
-        )
+        message = auth_pb2.AuthorizeRequest(resource=resource, permissions=permissions)
+        return self.__stub.Authorize(message, metadata=self._metadata)
 
-    def who_am_i(self) -> auth_proto.WhoAmIResponse:
+    def who_am_i(self) -> auth_pb2.WhoAmIResponse:
         """Returns info about the user tied to this `Client`.
 
         Returns
@@ -230,11 +239,12 @@ class AuthMixin:
             A protobuf object that returns the username and expiration for the
             token used.
         """
-        return self._req(Service.AUTH, "WhoAmI")
+        message = auth_pb2.WhoAmIRequest()
+        return self.__stub.WhoAmI(message, metadata=self._metadata)
 
     def get_roles_for_permission(
-        self, permission: auth_proto.Permission
-    ) -> List[auth_proto.Role]:
+        self, permission: auth_pb2.Permission
+    ) -> List[auth_pb2.Role]:
         """Returns a list of all roles that have the specified permission.
 
         Parameters
@@ -256,9 +266,8 @@ class AuthMixin:
 
         .. # noqa: W505
         """
-        return self._req(
-            Service.AUTH, "GetRolesForPermission", permission=permission
-        ).roles
+        message = auth_pb2.GetRolesForPermissionRequest(permission=permission)
+        return self.__stub.GetRolesForPermission(message, metadata=self._metadata).roles
 
     def get_robot_token(self, robot: str, ttl: int = None) -> str:
         """Gets a new auth token for a robot user.
@@ -276,7 +285,8 @@ class AuthMixin:
         str
             The new auth token.
         """
-        return self._req(Service.AUTH, "GetRobotToken", robot=robot, ttl=ttl).token
+        message = auth_pb2.GetRobotTokenRequest(robot=robot, ttl=ttl)
+        return self.__stub.GetRobotToken(message, metadata=self._metadata).token
 
     def revoke_auth_token(self, token: str) -> None:
         """Revokes an auth token.
@@ -286,7 +296,8 @@ class AuthMixin:
         token : str
             The Pachyderm token being revoked.
         """
-        self._req(Service.AUTH, "RevokeAuthToken", token=token)
+        message = auth_pb2.RevokeAuthTokenRequest(token=token)
+        self.__stub.RevokeAuthToken(message, metadata=self._metadata)
 
     def set_groups_for_user(self, username: str, groups: List[str]) -> None:
         """Sets the group membership for a user.
@@ -304,7 +315,8 @@ class AuthMixin:
 
         .. # noqa: W505
         """
-        self._req(Service.AUTH, "SetGroupsForUser", username=username, groups=groups)
+        message = auth_pb2.SetGroupsForUserRequest(username=username, groups=groups)
+        self.__stub.SetGroupsForUser(message, metadata=self._metadata)
 
     def modify_members(
         self, group: str, add: List[str] = None, remove: List[str] = None
@@ -328,13 +340,8 @@ class AuthMixin:
         ...     remove=["user:someuser"]
         ... )
         """
-        self._req(
-            Service.AUTH,
-            "ModifyMembers",
-            group=group,
-            add=add,
-            remove=remove,
-        )
+        message = auth_pb2.ModifyMembersRequest(group=group, add=add, remove=remove)
+        self.__stub.ModifyMembers(message, metadata=self._metadata)
 
     def get_groups(self) -> List[str]:
         """Gets a list of groups this user belongs to.
@@ -344,7 +351,8 @@ class AuthMixin:
         List[str]
             List of groups the user belongs to.
         """
-        return self._req(Service.AUTH, "GetGroups").groups
+        message = auth_pb2.GetGroupsRequest()
+        return self.__stub.GetGroups(message, metadata=self._metadata).groups
 
     def get_users(self, group: str) -> List[str]:
         """Gets users in a group.
@@ -359,7 +367,8 @@ class AuthMixin:
         List[str]
             All the users in the specified group.
         """
-        return self._req(Service.AUTH, "GetUsers", group=group).usernames
+        message = auth_pb2.GetUsersRequest(group=group)
+        return self.__stub.GetUsers(message, metadata=self._metadata).usernames
 
     def extract_auth_tokens(self):
         """This maps to an internal function that is only used for migration.

--- a/src/python_pachyderm/service.py
+++ b/src/python_pachyderm/service.py
@@ -27,6 +27,9 @@ from python_pachyderm.proto.v2.version.versionpb import version_pb2_grpc as vers
 
 MB = 1024 ** 2
 MAX_RECEIVE_MESSAGE_SIZE = 20 * MB
+GRPC_CHANNEL_OPTIONS = [
+    ("grpc.max_receive_message_length", MAX_RECEIVE_MESSAGE_SIZE),
+]
 
 
 class Service(Enum):


### PR DESCRIPTION
Here's a preliminary refactor of the `AdminMixin` and `AuthMixin` classes where requests are no longer routed through the `Client` class. Doing so this way I believe increases readability and would drastically reduce the linting we do for these mixins. If this was implemented in all the mixin classes then I believe that the `self._req` method would be unnecessary as well as `service.py`. 

Currently the only unpleasant part of this setup is that it requires each method to pass the metadata object in, but I believe even that can be alleviated with a gRPC interceptor. Using something like [this](https://github.com/d5h-foss/grpc-interceptor) we could attach a client interceptor to the `Client._channel` object which intercepts all the outgoing grpc buffers and appends the required metadata. If that turns out to be true than this could be really ergonomic to use!