### PR TITLE
[Bugfix] Cannot get large files from PFS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.5b0
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3

--- a/src/python_pachyderm/experimental/client.py
+++ b/src/python_pachyderm/experimental/client.py
@@ -37,6 +37,9 @@ class ProtoIterator:
     def __iter__(self):
         return self
 
+    def cancel(self) -> None:
+        self.stream.cancel()
+
 
 # converts enum values (ints) to their actual enum objects
 def _show_enums(bp_obj: betterproto.Message):

--- a/src/python_pachyderm/experimental/mixin/pfs.py
+++ b/src/python_pachyderm/experimental/mixin/pfs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from contextlib import contextmanager
 from typing import Iterator, Union, List, BinaryIO
 
-from python_pachyderm.mixin.pfs import PFSFile, PfsTarFile
+from python_pachyderm.mixin.pfs import PFSFile, PFSTarFile
 from python_pachyderm.experimental.pfs import commit_from, Commit, uuid_re
 from python_pachyderm.service import Service, pfs_proto as pfs_proto_pb
 from python_pachyderm.experimental.service import pfs_proto
@@ -862,7 +862,7 @@ class PFSMixin:
         datum: str = None,
         URL: str = None,
         offset: int = 0,
-    ) -> PfsTarFile:
+    ) -> PFSTarFile:
         """Gets a file from PFS.
 
         Parameters
@@ -892,7 +892,7 @@ class PFSMixin:
                 offset=offset,
             ),
         )
-        return PfsTarFile.open(fileobj=PFSFile(stream), mode="r|*")
+        return PFSTarFile.open(fileobj=PFSFile(stream), mode="r|*")
 
     def inspect_file(
         self,

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -5,56 +5,26 @@ import tarfile
 from contextlib import contextmanager
 from typing import Iterator, Union, List, BinaryIO
 
+import grpc
+from betterproto import BytesValue
+
 from python_pachyderm.pfs import commit_from, uuid_re, SubcommitType
 from python_pachyderm.service import pfs_proto, Service
 from google.protobuf import empty_pb2, wrappers_pb2
 
-
 BUFFER_SIZE = 19 * 1024 * 1024
 
 
-class FileTarstream:
-    """Implements a file-like interface over a GRPC byte stream,
-    so we can use tarfile to decode the file contents.
-    """
-
-    def __init__(self, res):
-        self.res = res
-        self.buf = []
-
-    def __next__(self):
-        return next(self.res).value
-
-    def close(self):
-        self.res.cancel()
-
-    def read(self, size=-1):
-        if self.res.cancelled():
-            return b""
-
-        buf = []
-        remaining = size if size >= 0 else 2 ** 32
-
-        if self.buf:
-            buf.append(self.buf[:remaining])
-            self.buf = self.buf[remaining:]
-            remaining -= len(buf[-1])
-
-        try:
-            while remaining > 0:
-                b = next(self)
-
-                if len(b) > remaining:
-                    buf.append(b[:remaining])
-                    self.buf = b[remaining:]
-                else:
-                    buf.append(b)
-
-                remaining -= len(buf[-1])
-        except StopIteration:
-            pass
-
-        return b"".join(buf)
+class PfsTarFile(tarfile.TarFile):
+    def __iter__(self):
+        for tarinfo in super().__iter__():
+            if tarinfo.path.startswith("/"):
+                # Hack to prevent extraction to absolute paths.
+                tarinfo.path = tarinfo.path[1:]
+            if tarinfo.mode == 0:
+                # Hack to prevent writing files with no permissions.
+                tarinfo.mode = 0o700
+            yield tarinfo
 
 
 class PFSFile:
@@ -71,32 +41,21 @@ class PFSFile:
     >>>     content = f.read()
     """
 
-    def __init__(self, stream, is_tar=False):
-        if is_tar:
-            # Pachyderm's GetFileTar API returns its result (which may include
-            # several files, e.g. when getting a directory) as a tar
-            # stream--untar the response byte stream as we receive it from
-            # GetFileTar.
-            # TODO how to handle multiple files in the tar stream?
-            f = tarfile.open(fileobj=stream, mode="r|*")
-            self._file = f.extractfile(f.next())
-        else:
-            self._file = stream
+    def __init__(self, stream: Iterator[BytesValue]):
+        self._stream = stream
+        self._buffer = bytearray()
+
+        try:
+            first_message = next(self._stream)
+        except grpc.RpcError as err:
+            raise ConnectionError("Error creating the PFSFile") from err
+        self._buffer.extend(first_message.value)
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, val, tb):
         self.close()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        x = self.read()
-        if not x:
-            raise StopIteration
-        return x
 
     def read(self, size: int = -1) -> bytes:
         """Reads from the :class:`.PFSFile` buffer.
@@ -111,11 +70,28 @@ class PFSFile:
         bytes
             Content from the stream.
         """
-        return self._file.read(size)
+        try:
+            if size == -1:
+                # Consume the entire stream.
+                for message in self._stream:
+                    self._buffer.extend(message.value)
+                result, self._buffer[:] = self._buffer[:], b""
+                return bytes(result)
+            elif len(self._buffer) < size:
+                for message in self._stream:
+                    self._buffer.extend(message.value)
+                    if len(self._buffer) >= size:
+                        break
+        except grpc.RpcError:
+            pass
+
+        size = min(size, len(self._buffer))
+        result, self._buffer[:size] = self._buffer[:size], b""
+        return bytes(result)
 
     def close(self) -> None:
         """Closes the :class:`.PFSFile`."""
-        self._file.close()
+        self._stream.cancel()
 
 
 class PFSMixin:
@@ -942,14 +918,14 @@ class PFSMixin:
         PFSFile
             The contents of the file in a file-like object.
         """
-        res = self._req(
+        stream = self._req(
             Service.PFS,
             "GetFile",
             file=pfs_proto.File(commit=commit_from(commit), path=path, datum=datum),
             URL=URL,
             offset=offset,
         )
-        return PFSFile(io.BytesIO(next(res).value))
+        return PFSFile(stream)
 
     def get_file_tar(
         self,
@@ -958,7 +934,7 @@ class PFSMixin:
         datum: str = None,
         URL: str = None,
         offset: int = 0,
-    ) -> PFSFile:
+    ) -> PfsTarFile:
         """Gets a file from PFS.
 
         Parameters
@@ -979,7 +955,7 @@ class PFSMixin:
         PFSFile
             The contents of the file in a file-like object.
         """
-        res = self._req(
+        stream = self._req(
             Service.PFS,
             "GetFileTAR",
             req=pfs_proto.GetFileRequest(
@@ -988,7 +964,7 @@ class PFSMixin:
                 offset=offset,
             ),
         )
-        return PFSFile(io.BytesIO(next(res).value), is_tar=True)
+        return PfsTarFile.open(fileobj=PFSFile(stream), mode="r|*")
 
     def inspect_file(
         self,

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -24,7 +24,7 @@ class PfsTarFile(tarfile.TarFile):
                 tarinfo.path = tarinfo.path[1:]
             if tarinfo.mode == 0:
                 # Hack to prevent writing files with no permissions.
-                tarinfo.mode = 0o600
+                tarinfo.mode = 0o700
             yield tarinfo
 
 

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -16,7 +16,7 @@ from google.protobuf import empty_pb2, wrappers_pb2
 BUFFER_SIZE = 19 * 1024 * 1024
 
 
-class PfsTarFile(tarfile.TarFile):
+class PFSTarFile(tarfile.TarFile):
     def __iter__(self):
         for tarinfo in super().__iter__():
             if os.path.isabs(tarinfo.path):
@@ -935,7 +935,7 @@ class PFSMixin:
         datum: str = None,
         URL: str = None,
         offset: int = 0,
-    ) -> PfsTarFile:
+    ) -> PFSTarFile:
         """Gets a file from PFS.
 
         Parameters
@@ -965,7 +965,7 @@ class PFSMixin:
                 offset=offset,
             ),
         )
-        return PfsTarFile.open(fileobj=PFSFile(stream), mode="r|*")
+        return PFSTarFile.open(fileobj=PFSFile(stream), mode="r|*")
 
     def inspect_file(
         self,

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -1,4 +1,5 @@
 import io
+import os
 import re
 import itertools
 import tarfile
@@ -18,7 +19,7 @@ BUFFER_SIZE = 19 * 1024 * 1024
 class PfsTarFile(tarfile.TarFile):
     def __iter__(self):
         for tarinfo in super().__iter__():
-            if tarinfo.path.startswith("/"):
+            if os.path.isabs(tarinfo.path):
                 # Hack to prevent extraction to absolute paths.
                 tarinfo.path = tarinfo.path[1:]
             if tarinfo.mode == 0:

--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -24,7 +24,7 @@ class PfsTarFile(tarfile.TarFile):
                 tarinfo.path = tarinfo.path[1:]
             if tarinfo.mode == 0:
                 # Hack to prevent writing files with no permissions.
-                tarinfo.mode = 0o700
+                tarinfo.mode = 0o600
             yield tarinfo
 
 

--- a/src/python_pachyderm/service.py
+++ b/src/python_pachyderm/service.py
@@ -25,7 +25,7 @@ from python_pachyderm.proto.v2.transaction import (
 from python_pachyderm.proto.v2.version.versionpb import version_pb2 as version_proto
 from python_pachyderm.proto.v2.version.versionpb import version_pb2_grpc as version_grpc
 
-MB = 1024 ** 2
+MB = 1024**2
 MAX_RECEIVE_MESSAGE_SIZE = 20 * MB
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -530,8 +530,8 @@ def test_list_commit():
         pass
 
     commits = list(
-        *client.list_commit("list_commit1"),
-        *client.list_commit("list_commit2"),
+        *client.list_commit(repo_name1),
+        *client.list_commit(repo_name2),
     )
     for commit in commits:
         print(commit)

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -529,7 +529,12 @@ def test_list_commit():
     with client.commit(repo_name2, "master"):
         pass
 
-    commits = list(client.list_commit())
+    commits = list(
+        *client.list_commit("list_commit1"),
+        *client.list_commit("list_commit2"),
+    )
+    for commit in commits:
+        print(commit)
     assert len(commits) == 3
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -529,12 +529,11 @@ def test_list_commit():
     with client.commit(repo_name2, "master"):
         pass
 
-    commits = [
-        *client.list_commit(repo_name1),
-        *client.list_commit(repo_name2),
-    ]
-    for commit in commits:
-        print(commit)
+    commits = list(client.list_commit())
+    # commits = [
+    #     *client.list_commit(repo_name1),
+    #     *client.list_commit(repo_name2),
+    # ]
     assert len(commits) == 3
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -530,6 +530,9 @@ def test_list_commit():
         pass
 
     commits = list(client.list_commit())
+    print()
+    for commit in commits:
+        print(commit)
     assert len(commits) == 3
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -530,10 +530,6 @@ def test_list_commit():
         pass
 
     commits = list(client.list_commit())
-    # commits = [
-    #     *client.list_commit(repo_name1),
-    #     *client.list_commit(repo_name2),
-    # ]
     assert len(commits) == 3
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -530,9 +530,6 @@ def test_list_commit():
         pass
 
     commits = list(client.list_commit())
-    print()
-    for commit in commits:
-        print(commit)
     assert len(commits) == 3
 
 

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -738,7 +738,8 @@ def test_mount():
 
 @pytest.fixture(name="repo")
 def _repo_fixture(request) -> str:
-    return request.node.nodeid.replace(":", "-").replace(".py", "")
+    """Create a repository name from the test function name."""
+    return request.node.nodeid.replace("/", "-").replace(":", "-").replace(".py", "")
 
 
 @pytest.fixture(name="client")

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -808,7 +808,14 @@ class TestPFSFile:
 
     @staticmethod
     def test_context_manager(client: Client, repo: str):
-        """Test that the PFSFile context manager cleans up as expected."""
+        """Test that the PFSFile context manager cleans up as expected.
+
+        Note: The test file needs to be large in order to span multiple
+          gRPC messages. If the file only requires a single message to stream
+          then the stream will be terminated and the assertion within the
+          `client.get_file` context will fail.
+          Maybe this should be rethought or mocked in the future.
+        """
         # Arrange
         data = os.urandom(int(MAX_RECEIVE_MESSAGE_SIZE * 1.1))
         pfs_file = "/test_file.dat"
@@ -819,9 +826,24 @@ class TestPFSFile:
         # Act & Assert
         with client.get_file(commit, pfs_file) as file:
             assert file._stream.stream.is_active()
-
-        # Assert
         assert not file._stream.stream.is_active()
+
+    @staticmethod
+    def test_cancelled_stream(client: Client, repo: str):
+        """Test that a cancelled stream maintains the integrity of the
+        already-streamed data.
+        """
+        # Arrange
+        data = os.urandom(200)
+        pfs_file = "/test_file.dat"
+
+        with client.commit(repo, "master") as commit:
+            client.put_file_bytes(commit, pfs_file, data)
+
+        # Act & Assert
+        with client.get_file(commit, pfs_file) as file:
+            assert file.read(100) == data[:100]
+        assert file.read(100) == data[100:]
 
     @staticmethod
     def test_get_file_tar(client: Client, repo: str, tmp_path: Path):

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -529,10 +529,10 @@ def test_list_commit():
     with client.commit(repo_name2, "master"):
         pass
 
-    commits = list(
+    commits = [
         *client.list_commit(repo_name1),
         *client.list_commit(repo_name2),
-    )
+    ]
     for commit in commits:
         print(commit)
     assert len(commits) == 3

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 
 """Tests PFS-related functionality"""
-
-import pytest
+import os
 import tempfile
 from io import BytesIO
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from betterproto import BytesValue
 
 import python_pachyderm
-from python_pachyderm.service import pfs_proto
+from python_pachyderm import Client, PFSFile
+from python_pachyderm.service import pfs_proto, MAX_RECEIVE_MESSAGE_SIZE
 from tests import util
 
 
@@ -321,50 +326,6 @@ def test_put_file_atomic():
     files = list(client.list_file(commit, ""))
     assert len(files) == 1
     assert files[0].file.path == "/index.html"
-
-
-def test_get_file():
-    client, repo_name = sandbox("get_file")
-    commit = (repo_name, "master")
-
-    with client.modify_file_client(commit) as mfc:
-        mfc.put_file_from_fileobj("file1.dat", BytesIO(b"DATA1"))
-
-    assert client.get_file(commit, "file1.dat").read() == b"DATA1"
-
-
-def test_get_file_tar():
-    client, repo_name = sandbox("get_file_tar")
-    commit = (repo_name, "master")
-
-    with client.modify_file_client(commit) as mfc:
-        mfc.put_file_from_fileobj("file1.dat", BytesIO(b"DATA1"))
-
-    assert client.get_file_tar(commit, "file1.dat").read() == b"DATA1"
-
-
-def test_PFSFile_with():
-    client, repo_name = sandbox("PFSFile_with")
-    commit = (repo_name, "master")
-
-    with client.modify_file_client(commit) as mfc:
-        mfc.put_file_from_fileobj("file1.dat", BytesIO(b"DATA1"))
-
-    with client.get_file_tar(commit, "file1.dat") as f:
-        assert f.read() == b"DATA1"
-
-    with pytest.raises(ValueError, match="read of closed file"):
-        f.read()
-
-
-def test_PFSFile_iter():
-    client, repo_name = sandbox("PFSFile_iter")
-    commit = (repo_name, "master")
-
-    with client.modify_file_client(commit) as mfc:
-        mfc.put_file_from_fileobj("file1.dat", BytesIO(b"DATA1"))
-
-    assert list(client.get_file(commit, "file1.dat"))[0] == b"DATA1"
 
 
 def test_copy_file():
@@ -771,3 +732,115 @@ def test_modify_file_client():
     files = list(client.list_file(c2, "/"))
     assert len(files) == 2
     assert "/file3.txt" in [f.file.path for f in files]
+
+
+@pytest.fixture(name="repo")
+def _repo_fixture(request) -> str:
+    return request.node.nodeid.replace(":", "-").replace(".py", "")
+
+
+@pytest.fixture(name="client")
+def _client_fixture(repo):
+    client = Client()
+    client.delete_repo(repo, force=True)
+    client.create_repo(repo, "test repo for python_pachyderm")
+    yield client
+    client.delete_repo(repo, force=True)
+
+
+class TestPFSFile:
+    @staticmethod
+    def test_get_large_file(client: Client, repo: str):
+        """Test that a large file (requires >1 gRPC message to stream)
+        is successfully streamed in it's entirety
+        """
+        # Arrange
+        data = os.urandom(int(MAX_RECEIVE_MESSAGE_SIZE * 1.1))
+        pfs_file = "/large_file.dat"
+
+        with client.commit(repo, "large_file_commit") as commit:
+            client.put_file_bytes(commit, pfs_file, data)
+
+        # Act
+        with client.get_file(commit, pfs_file) as file:
+            assert len(file._buffer) < len(data), (
+                "PFSFile initialization streams the first message. "
+                "This asserts that the test file must be streamed over multiple messages. "
+            )
+            streamed_data = file.read()
+
+        # Assert
+        assert streamed_data[:10] == data[:10]
+        assert streamed_data[-10:] == data[-10:]
+        assert len(streamed_data) == len(data)
+
+    @staticmethod
+    def test_buffered_data(client: Client, repo: str):
+        """Test that data gets buffered as expected."""
+        # Arrange
+        stream_items = [b"a", b"bc", b"def", b"ghij", b"klmno"]
+        stream = (BytesValue(value=item) for item in stream_items)
+
+        # Act
+        file = PFSFile(stream)
+
+        # Assert
+        assert file._buffer == b"a"
+        assert file.read(0) == b""
+        assert file._buffer == b"a"
+        assert file.read(2) == b"ab"
+        assert file._buffer == b"c"
+        assert file.read(5) == b"cdefg"
+        assert file._buffer == b"hij"
+
+    @staticmethod
+    def test_fail_early(client: Client, repo: str):
+        """Test that gRPC errors are caught and thrown early."""
+        # Arrange
+        commit = (repo, "master")
+
+        # Act & Assert
+        with pytest.raises(ConnectionError):
+            client.get_file(commit, "there is no file")
+
+    @staticmethod
+    def test_context_manager(client: Client, repo: str):
+        """Test that the PFSFile context manager cleans up as expected."""
+        # Arrange
+        data = os.urandom(int(MAX_RECEIVE_MESSAGE_SIZE * 1.1))
+        pfs_file = "/test_file.dat"
+
+        with client.commit(repo, "master") as commit:
+            client.put_file_bytes(commit, pfs_file, data)
+
+        # Act & Assert
+        with client.get_file(commit, pfs_file) as file:
+            assert file._stream.is_active()
+
+        # Assert
+        assert not file._stream.is_active()
+
+    @staticmethod
+    def test_get_file_tar(client: Client, repo: str, tmp_path: Path):
+        """Test that retrieving a TAR of a PFS directory works as expected."""
+        # Arrange
+        TestPfsFile = NamedTuple("TestPfsFile", (("data", bytes), ("path", str)))
+        test_files = [
+            TestPfsFile(os.urandom(1024), "/a.dat"),
+            TestPfsFile(os.urandom(2048), "/child/b.dat"),
+            TestPfsFile(os.urandom(5000), "/child/grandchild/c.dat"),
+        ]
+
+        with client.commit(repo, "master") as commit:
+            for test_file in test_files:
+                client.put_file_bytes(commit, test_file.path, test_file.data)
+
+        # Act
+        with client.get_file_tar(commit, "/") as tar:
+            tar.extractall(tmp_path)
+
+        # Assert
+        for test_file in test_files:
+            local_file = tmp_path.joinpath(test_file.path[1:])
+            assert local_file.exists()
+            assert local_file.read_bytes() == test_file.data

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -736,7 +736,8 @@ def test_modify_file_client():
 
 @pytest.fixture(name="repo")
 def _repo_fixture(request) -> str:
-    return request.node.nodeid.replace(":", "-").replace(".py", "")
+    """Create a repository name from the test function name."""
+    return request.node.nodeid.replace("/", "-").replace(":", "-").replace(".py", "")
 
 
 @pytest.fixture(name="client")

--- a/tests/test_spout.py
+++ b/tests/test_spout.py
@@ -21,6 +21,7 @@ def test_create_spout():
     )
 
     assert len(list(client.list_pipeline())) == 1
+    client.delete_all()
 
 
 @pytest.mark.timeout(45)
@@ -50,3 +51,4 @@ def test_spout_commit():
 
     commit_infos = list(client.list_commit("pipeline-spout-commit"))
     assert len(commit_infos) == 1
+    client.delete_all()

--- a/tests/test_spout.py
+++ b/tests/test_spout.py
@@ -21,7 +21,6 @@ def test_create_spout():
     )
 
     assert len(list(client.list_pipeline())) == 1
-    client.delete_all()
 
 
 @pytest.mark.timeout(45)
@@ -51,4 +50,3 @@ def test_spout_commit():
 
     commit_infos = list(client.list_commit("pipeline-spout-commit"))
     assert len(commit_infos) == 1
-    client.delete_all()

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "pachyderm": "2.0.2",
+    "pachyderm": "2.0.5",
     "kubernetes": "1.21.0",
     "minikube": "1.22.0"
 }


### PR DESCRIPTION
This fixes an issue where a users could not retrieve more than 20MiB of a file using `client.get_file`. This also creates a working implementation for `client.get_file_tar`. 