### PR TITLE
b64 decode the server_cas string when parsing a config file

### DIFF
--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -1,5 +1,6 @@
 import os
 import json
+from base64 import b64decode
 from pathlib import Path
 from typing import Optional, TextIO
 from urllib.parse import urlparse
@@ -424,7 +425,10 @@ class Client(
         host = u.hostname
         port = u.port
         tls = u.scheme == "grpcs" or u.scheme == "https"
-        root_certs = bytes(root_certs, "utf-8") if root_certs is not None else None
+        print(root_certs)
+        root_certs = (
+            b64decode(bytes(root_certs, "utf-8")) if root_certs is not None else None
+        )
 
         return host, port, pachd_address, auth_token, root_certs, transaction_id, tls
 

--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -425,7 +425,6 @@ class Client(
         host = u.hostname
         port = u.port
         tls = u.scheme == "grpcs" or u.scheme == "https"
-        print(root_certs)
         root_certs = (
             b64decode(bytes(root_certs, "utf-8")) if root_certs is not None else None
         )

--- a/tests/experimental/test_client.py
+++ b/tests/experimental/test_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import python_pachyderm
+from base64 import b64encode
 from tests import util
 
 """Tests generic client functionality"""
@@ -97,6 +98,9 @@ def test_check_config_order(mocker):
 
 
 def test_parse_config():
+    server_cas = b"foo"
+    server_cas_base64 = b64encode(server_cas)
+
     (
         host,
         port,
@@ -114,7 +118,7 @@ def test_parse_config():
             "contexts": {
               "local": {
                 "pachd_address": "grpcs://172.17.0.6:30650",
-                "server_cas": "foo",
+                "server_cas": "%s",
                 "session_token": "bar",
                 "active_transaction": "baz"
               }
@@ -122,13 +126,14 @@ def test_parse_config():
           }
         }
         """
+            % server_cas_base64.decode()
         )
     )
     assert host == "172.17.0.6"
     assert port == 30650
     assert pachd_address == "grpcs://172.17.0.6:30650"
     assert auth_token == "bar"
-    assert root_certs == b"foo"
+    assert root_certs == server_cas
     assert transaction_id == "baz"
     assert tls is True
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import python_pachyderm
+from base64 import b64encode
 from tests import util
 
 """Tests generic client functionality"""
@@ -97,6 +98,9 @@ def test_check_config_order(mocker):
 
 
 def test_parse_config():
+    server_cas = b"foo"
+    server_cas_base64 = b64encode(server_cas)
+
     (
         host,
         port,
@@ -114,7 +118,7 @@ def test_parse_config():
             "contexts": {
               "local": {
                 "pachd_address": "grpcs://172.17.0.6:30650",
-                "server_cas": "foo",
+                "server_cas": "%s",
                 "session_token": "bar",
                 "active_transaction": "baz"
               }
@@ -122,13 +126,14 @@ def test_parse_config():
           }
         }
         """
+            % server_cas_base64.decode()
         )
     )
     assert host == "172.17.0.6"
     assert port == 30650
     assert pachd_address == "grpcs://172.17.0.6:30650"
     assert auth_token == "bar"
-    assert root_certs == b"foo"
+    assert root_certs == server_cas
     assert transaction_id == "baz"
     assert tls is True
 


### PR DESCRIPTION
Motivation: the Pachyderm config file expects a base64-encoded PEM string for the `server_cas` field. `pachctl` is able to correctly decode this field and connect to the server using the certs. However, `python_pachyderm.Client` assumes the `server_cas` field is an unencoded PEM string when parsing the config file, which breaks clients that have the `server_cas` field populated.