### PR TITLE
Add handling for connection errors

### DIFF
--- a/src/python_pachyderm/interceptor.py
+++ b/src/python_pachyderm/interceptor.py
@@ -42,7 +42,7 @@ def _check_connection_error(grpc_future: grpc.Future):
             if "PACHD_PEER_SERVICE_HOST" in environ:
                 error_message += (
                     "\tPACHD_PEER_SERVICE_HOST is detected. "
-                    "Please use Client.new_in_cluster() when creating when using"
+                    "Please use Client.new_in_cluster() when using"
                     " python_pachyderm within the a pipeline. "
                 )
             raise ConnectionError(error_message) from error

--- a/src/python_pachyderm/interceptor.py
+++ b/src/python_pachyderm/interceptor.py
@@ -1,5 +1,5 @@
 from os import environ
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import grpc
 from grpc_interceptor import ClientCallDetails, ClientInterceptor
@@ -26,18 +26,24 @@ class MetadataClientInterceptor(ClientInterceptor):
         )
 
         future = method(request, new_details)
-        try:
-            future.result()
-            return future
-        except grpc.RpcError as error:
-            unable_to_connect = "failed to connect to all addresses" in error.details()
-            if error.code() == grpc.StatusCode.UNAVAILABLE and unable_to_connect:
-                error_message = "Could not connect to pachyderm instance\n"
-                if "PACHD_PEER_SERVICE_HOST" in environ:
-                    error_message += (
-                        "\tPACHD_PEER_SERVICE_HOST is detected. "
-                        "Please use Client.new_in_cluster() when creating when using"
-                        " python_pachyderm within the a pipeline. "
-                    )
-                raise ConnectionError(error_message) from error
-            raise error
+        future.add_done_callback(_check_connection_error)
+        return future
+
+
+def _check_connection_error(grpc_future: grpc.Future):
+    """Callback function that checks if a gRPC.Future experienced a
+    ConnectionError and attempt to sanitize the error message for the user.
+    """
+    error: Optional[grpc.Call] = grpc_future.exception()
+    if error is not None:
+        unable_to_connect = "failed to connect to all addresses" in error.details()
+        if error.code() == grpc.StatusCode.UNAVAILABLE and unable_to_connect:
+            error_message = "Could not connect to pachyderm instance\n"
+            if "PACHD_PEER_SERVICE_HOST" in environ:
+                error_message += (
+                    "\tPACHD_PEER_SERVICE_HOST is detected. "
+                    "Please use Client.new_in_cluster() when creating when using"
+                    " python_pachyderm within the a pipeline. "
+                )
+            raise ConnectionError(error_message) from error
+        raise error

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,6 +180,12 @@ def test_client_init_with_args():
     assert client.address == "pachd.example.com:54321"
 
 
+def test_client_connection_error():
+    client = python_pachyderm.Client(host="localhost", port=54321)
+    with pytest.raises(ConnectionError):
+        client.get_remote_version()
+
+
 def test_client_new_in_cluster_missing_envs():
     with pytest.raises(Exception):
         python_pachyderm.Client.new_in_cluster()


### PR DESCRIPTION
The user should no longer _only_ see:
```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses"
	debug_error_string = "{"created":"@1649864665.396757000","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3094,"referenced_errors":[{"created":"@1649864665.396756000","description":"failed to connect to all addresses","file":"src/core/lib/transport/error_utils.cc","file_line":163,"grpc_status":14}]}"
>
```

Also the error with provide some help if python_pachyderm is failing to connect from within a pipeline.