### PR TITLE
Add support for python3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,63 @@
 version: 2.1
 
+commands:
+  install-python:
+    parameters:
+      version:
+        type: string
+    steps:
+        - run:
+            name: Install python
+            command: |
+                git -C "/opt/circleci/.pyenv/" pull -q
+                pyenv install <<parameters.version>>
+                pyenv global <<parameters.version>>
+
+  install-poetry:
+    steps:
+      - run:
+          name: Install poetry
+          command: |
+            curl -fsS -o install-poetry.py https://install.python-poetry.org
+            python3 install-poetry.py
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+            rm install-poetry.py
+
+  deploy-pachyderm:
+    steps:
+      - run:
+          name: Install dependencies
+          command: etc/testing/circle/install.sh
+      - run:
+          name: Start minikube
+          command: etc/testing/circle/start-minikube.sh
+      - run:
+          name: Deploy pachyderm
+          command: etc/testing/circle/deploy-pachyderm.sh
+
 jobs:
+  unit-tests:
+    resource_class: large
+    parameters:
+        python-version:
+            type: string
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - deploy-pachyderm
+      - install-python
+          version: <<parameters.python-version>>
+      - install-poetry
+      - run:
+          name: Run unit tests
+          command: |
+            pachctl port-forward &
+            poetry install -v
+            poetry run pytest tests
+      - run:
+          when: on_fail
+          command: etc/testing/circle/kube_debug.sh
   tox:
     resource_class: large
     parameters:
@@ -57,6 +114,15 @@ jobs:
 workflows:
   circleci:
     jobs:
+      - unit-tests
+          matrix:
+            parameters:
+              python-version:
+                - 3.7.10
+                - 3.10.4
+          filters:
+            tags:
+              only: /.*/
       - tox:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,7 @@ workflows:
             tags:
               only: /.*/
       - examples:
-          parameters:
-            python-version:
-              - 3.9.6
+          python-version: 3.9.6
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,8 @@ workflows:
               only: /.*/
       - examples:
           parameters:
-            python-version: 3.9.6
+            python-version:
+              - 3.9.6
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ commands:
       version:
         type: string
     steps:
-        - run:
-            name: Install python
-            command: |
-                git -C "/opt/circleci/.pyenv/" checkout master -q
-                git -C "/opt/circleci/.pyenv/" pull -q
-                pyenv install <<parameters.version>>
-                pyenv global <<parameters.version>>
+      - run:
+          name: Install python
+          command: |
+            git -C "/opt/circleci/.pyenv/" checkout master -q
+            git -C "/opt/circleci/.pyenv/" pull -q
+            pyenv install <<parameters.version>>
+            pyenv global <<parameters.version>>
 
   install-poetry:
     steps:
@@ -100,41 +100,6 @@ jobs:
           name: Run linting
           command: poetry run make lint
 
-#  tox:
-#    resource_class: large
-#    parameters:
-#      toxenv:
-#        type: string
-#    machine:
-#      image: ubuntu-2004:202101-01
-#    steps:
-#      - checkout
-#      - run:
-#          name: Install dependencies
-#          command: etc/testing/circle/install.sh
-#      - when:
-#          condition:
-#            not:
-#              equal: [ lint, <<parameters.toxenv>> ]
-#          steps:
-#            - run:
-#                name: Start minikube
-#                command: etc/testing/circle/start-minikube.sh
-#            - run:
-#                name: Deploy pachyderm
-#                command: etc/testing/circle/deploy-pachyderm.sh
-#      - run:
-#          name: TOXENV=<<parameters.toxenv>> tox
-#          command: |
-#            pachctl port-forward &
-#            export PATH="$HOME/.local/bin:$PATH"
-#            python3 -m tox
-#          environment:
-#            TOXENV: << parameters.toxenv >>
-#      - run:
-#          when: on_fail
-#          command: etc/testing/circle/kube_debug.sh
-
   test-publish:
     docker:
       - image: circleci/python:3.9
@@ -168,20 +133,11 @@ workflows:
           filters:
             tags:
               only: /.*/
-#      - tox:
-#          matrix:
-#            parameters:
-#              toxenv:
-#                - py37
-#                - py310
-#                - lint
-#                - examples
-#          filters:
-#            tags:
-#              only: /.*/
       - test-publish:
-#          requires:
-#            - tox
+          requires:
+            - unit-tests
+            - examples
+            - linting
           filters:
             tags:
               only: /^\d+\.\d+\.\d.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,42 +98,43 @@ jobs:
       - create-venv
       - run:
           name: Run linting
-          command: make lint
+          command: poetry run make lint
 
-  tox:
-    resource_class: large
-    parameters:
-      toxenv:
-        type: string
-    machine:
-      image: ubuntu-2004:202101-01
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: etc/testing/circle/install.sh
-      - when:
-          condition:
-            not:
-              equal: [ lint, <<parameters.toxenv>> ]
-          steps:
-            - run:
-                name: Start minikube
-                command: etc/testing/circle/start-minikube.sh
-            - run:
-                name: Deploy pachyderm
-                command: etc/testing/circle/deploy-pachyderm.sh
-      - run:
-          name: TOXENV=<<parameters.toxenv>> tox
-          command: |
-            pachctl port-forward &
-            export PATH="$HOME/.local/bin:$PATH"
-            python3 -m tox
-          environment:
-            TOXENV: << parameters.toxenv >>
-      - run:
-          when: on_fail
-          command: etc/testing/circle/kube_debug.sh
+#  tox:
+#    resource_class: large
+#    parameters:
+#      toxenv:
+#        type: string
+#    machine:
+#      image: ubuntu-2004:202101-01
+#    steps:
+#      - checkout
+#      - run:
+#          name: Install dependencies
+#          command: etc/testing/circle/install.sh
+#      - when:
+#          condition:
+#            not:
+#              equal: [ lint, <<parameters.toxenv>> ]
+#          steps:
+#            - run:
+#                name: Start minikube
+#                command: etc/testing/circle/start-minikube.sh
+#            - run:
+#                name: Deploy pachyderm
+#                command: etc/testing/circle/deploy-pachyderm.sh
+#      - run:
+#          name: TOXENV=<<parameters.toxenv>> tox
+#          command: |
+#            pachctl port-forward &
+#            export PATH="$HOME/.local/bin:$PATH"
+#            python3 -m tox
+#          environment:
+#            TOXENV: << parameters.toxenv >>
+#      - run:
+#          when: on_fail
+#          command: etc/testing/circle/kube_debug.sh
+
   test-publish:
     docker:
       - image: circleci/python:3.9
@@ -167,17 +168,17 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - tox:
-          matrix:
-            parameters:
-              toxenv:
-                - py37
-                - py310
-                - lint
-                - examples
-          filters:
-            tags:
-              only: /.*/
+#      - tox:
+#          matrix:
+#            parameters:
+#              toxenv:
+#                - py37
+#                - py310
+#                - lint
+#                - examples
+#          filters:
+#            tags:
+#              only: /.*/
       - test-publish:
           requires:
             - tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ commands:
             name: Install python
             command: |
                 git -C "/opt/circleci/.pyenv/" pull -q
-                rm .python-version
                 pyenv install <<parameters.version>>
                 pyenv global <<parameters.version>>
 
@@ -43,7 +42,7 @@ jobs:
         python-version:
             type: string
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202111-01
     steps:
       - checkout
       - deploy-pachyderm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
             parameters:
               toxenv:
                 - py37
-                - py39
+                - py310
                 - lint
                 - examples
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2.1
 
 commands:
+  deploy-pachyderm:
+    steps:
+      - run:
+          name: Install dependencies
+          command: etc/testing/circle/install.sh
+      - run:
+          name: Start minikube
+          command: etc/testing/circle/start-minikube.sh
+      - run:
+          name: Deploy pachyderm
+          command: etc/testing/circle/deploy-pachyderm.sh
+
   install-python:
     parameters:
       version:
@@ -9,6 +21,7 @@ commands:
         - run:
             name: Install python
             command: |
+                git -C "/opt/circleci/.pyenv/" checkout master -q
                 git -C "/opt/circleci/.pyenv/" pull -q
                 pyenv install <<parameters.version>>
                 pyenv global <<parameters.version>>
@@ -23,24 +36,18 @@ commands:
             echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
             rm install-poetry.py
 
-  deploy-pachyderm:
+  create-venv:
     steps:
       - run:
-          name: Install dependencies
-          command: etc/testing/circle/install.sh
-      - run:
-          name: Start minikube
-          command: etc/testing/circle/start-minikube.sh
-      - run:
-          name: Deploy pachyderm
-          command: etc/testing/circle/deploy-pachyderm.sh
+          name: Create virtual environment
+          command: poetry install -v
 
 jobs:
   unit-tests:
     resource_class: large
     parameters:
-        python-version:
-            type: string
+      python-version:
+        type: string
     machine:
       image: ubuntu-2004:202111-01
     steps:
@@ -49,15 +56,50 @@ jobs:
       - install-python:
           version: <<parameters.python-version>>
       - install-poetry
+      - create-venv
       - run:
           name: Run unit tests
           command: |
             pachctl port-forward &
-            poetry install -v
             poetry run pytest tests
       - run:
           when: on_fail
           command: etc/testing/circle/kube_debug.sh
+
+  examples:
+    resource_class: large
+    parameters:
+      python-version:
+        type: string
+    machine:
+      image: ubuntu-2004:202111-01
+    steps:
+      - checkout
+      - deploy-pachyderm
+      - install-python:
+          version: <<parameters.python-version>>
+      - install-poetry
+      - create-venv
+      - run:
+          name: Run opencv example
+          command: |
+            pachctl port-forward &
+            poetry run python ./examples/opencv/opencv.py
+      - run:
+          when: on_fail
+          command: etc/testing/circle/kube_debug.sh
+
+  linting:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - install-poetry
+      - create-venv
+      - run:
+          name: Run linting
+          command: make lint
+
   tox:
     resource_class: large
     parameters:
@@ -94,18 +136,11 @@ jobs:
           command: etc/testing/circle/kube_debug.sh
   test-publish:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     steps:
       - checkout
-      - run:
-          name: Install poetry
-          command: |
-              curl -fsS -o get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
-              python get-poetry.py -y
-      - run:
-          name: Install deps
-          command: |
-              poetry install
+      - install-poetry
+      - create-venv
       - run:
           name: build + publish
           command: |
@@ -120,6 +155,16 @@ workflows:
               python-version:
                 - 3.7.10
                 - 3.10.4
+          filters:
+            tags:
+              only: /.*/
+      - examples:
+          parameters:
+            python-version: 3.9.6
+          filters:
+            tags:
+              only: /.*/
+      - linting:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,8 +180,8 @@ workflows:
 #            tags:
 #              only: /.*/
       - test-publish:
-          requires:
-            - tox
+#          requires:
+#            - tox
           filters:
             tags:
               only: /^\d+\.\d+\.\d.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - checkout
       - deploy-pachyderm
-      - install-python
+      - install-python:
           version: <<parameters.python-version>>
       - install-poetry
       - run:
@@ -114,7 +114,7 @@ jobs:
 workflows:
   circleci:
     jobs:
-      - unit-tests
+      - unit-tests:
           matrix:
             parameters:
               python-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ commands:
             name: Install python
             command: |
                 git -C "/opt/circleci/.pyenv/" pull -q
+                rm .python-version
                 pyenv install <<parameters.version>>
                 pyenv global <<parameters.version>>
 

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -24,8 +24,6 @@ cd /opt/circleci/.pyenv/plugins/python-build/../.. \
   && pyenv global 3.10.4
 
 # Install tox
-#export PATH="/home/circleci/.local/bin:$PATH"
-#curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 pip3 install tox
 
 # Install poetry

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -19,6 +19,9 @@ sudo apt-get install -y -qq \
   jq \
   socat
 
+cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+pyenv install 3.10.4
+
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
 sudo apt-get install apt-transport-https --yes

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -4,13 +4,9 @@ set -ex
 
 mkdir -p cached-deps
 
-sudo add-apt-repository ppa:deadsnakes/ppa
-
 # Install deps
 sudo apt update -y
 sudo apt-get install -y -qq \
-  python3.7 \
-  python3.7-distutils \
   pkg-config \
   conntrack \
   pv \
@@ -49,15 +45,3 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 # Install Pachyderm
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
-
-#git -C "/opt/circleci/.pyenv/" pull -q \
-#  && pyenv install 3.10.4 \
-#  && pyenv global 3.10.4
-#
-## Install tox
-#pip3 install tox
-#
-## Install poetry
-#curl -fsS -o install-poetry.py https://install.python-poetry.org
-#python3 install-poetry.py
-#rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -18,10 +18,20 @@ sudo apt-get install -y -qq \
   socat
 
 cd /opt/circleci/.pyenv/plugins/python-build/../.. \
-  && git pull \
+  && git pull -q \
   && cd - \
   && pyenv install 3.10.4 \
   && pyenv global 3.10.4
+
+# Install tox
+#export PATH="/home/circleci/.local/bin:$PATH"
+#curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+pip3 install tox
+
+# Install poetry
+curl -fsS -o install-poetry.py https://install.python-poetry.org
+python3 install-poetry.py -y
+rm install-poetry.py
 
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
@@ -55,15 +65,3 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 # Install Pachyderm
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
-
-pyenv install 3.10.4
-
-# Install tox
-#export PATH="/home/circleci/.local/bin:$PATH"
-#curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-pip3 install tox
-
-# Install poetry
-curl -fsS -o install-poetry.py https://install.python-poetry.org
-python3 install-poetry.py -y
-rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -12,7 +12,6 @@ sudo apt-get install -y -qq \
   python3.7 \
   python3.10 \
   python3.10-pip \
-  python3.10-setuptools \
   python3.7-distutils \
   pkg-config \
   conntrack \

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -55,9 +55,9 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
-pip3 install tox
+pip3.10 install tox
 
 # Install poetry
 curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3 install-poetry.py -y --version 1.1.8
+python3.10 install-poetry.py -y --version 1.1.8
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -9,17 +9,16 @@ sudo add-apt-repository ppa:deadsnakes/ppa
 # Install deps
 sudo apt update -y
 sudo apt-get install -y -qq \
-  python3 \
-  python3-pip \
-  python3-setuptools \
+  python3.7 \
+  python3.10 \
+  python3.10-pip \
+  python3.10-setuptools \
   python3.7-distutils \
   pkg-config \
   conntrack \
   pv \
   jq \
-  socat \
-  python3.7 \
-  python3.10
+  socat
 
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
@@ -55,9 +54,9 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
-pip3.10 install tox
+pip3 install tox
 
 # Install poetry
 curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3.10 install-poetry.py -y --version 1.1.8
+python3 install-poetry.py -y --version 1.1.8
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -27,7 +27,7 @@ cd /opt/circleci/.pyenv/plugins/python-build/../.. \
 pip3 install tox
 
 # Install poetry
-curl -fsS -o install-poetry.py https://install.python-poetry.org
+curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
 python3 install-poetry.py -y
 rm install-poetry.py
 
@@ -63,5 +63,3 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 # Install Pachyderm
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
-
-cat /home/circleci/.bashrc

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -52,9 +52,7 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
 
-echo `which python3`
-echo `which python3.7`
-echo `which python3.10`
+pyenv install 3.10.4
 
 # Install tox
 export PATH="/home/circleci/.local/bin:$PATH"

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -50,10 +50,7 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
 
-cd /opt/circleci/.pyenv/plugins/python-build/../.. \
-  && git pull -q \
-  && cd - \
-  && echo `pwd` \
+git -C "/opt/circleci/.pyenv/" pull -q \
   && pyenv install 3.10.4 \
   && pyenv global 3.10.4
 

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -11,7 +11,7 @@ sudo apt update -y
 sudo apt-get install -y -qq \
   python3.7 \
   python3.10 \
-  python3.10-pip \
+  python3.10-distutils \
   python3.7-distutils \
   pkg-config \
   conntrack \
@@ -53,7 +53,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
-pip3 install tox
+python3 -m pip install tox
 
 # Install poetry
 curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -63,3 +63,5 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 # Install Pachyderm
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
+
+cat /home/circleci/.bashrc

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y -qq \
   jq \
   socat \
   python3.7 \
-  python3.9
+  python3.10
 
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -53,9 +53,9 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
-python3 -m pip install tox
+python3.10 -m pip install tox
 
 # Install poetry
 curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3 install-poetry.py -y --version 1.1.8
+python3.10 install-poetry.py -y --version 1.1.8
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -57,6 +57,6 @@ curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 python3.10 -m pip install tox
 
 # Install poetry
-curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3.10 install-poetry.py -y --version 1.1.8
+curl -fsS -o install-poetry.py https://install.python-poetry.org
+python3.10 install-poetry.py -y
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -17,20 +17,6 @@ sudo apt-get install -y -qq \
   jq \
   socat
 
-cd /opt/circleci/.pyenv/plugins/python-build/../.. \
-  && git pull -q \
-  && cd - \
-  && pyenv install 3.10.4 \
-  && pyenv global 3.10.4
-
-# Install tox
-pip3 install tox
-
-# Install poetry
-curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3 install-poetry.py -y
-rm install-poetry.py
-
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
 sudo apt-get install apt-transport-https --yes
@@ -63,3 +49,17 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 # Install Pachyderm
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
+
+cd /opt/circleci/.pyenv/plugins/python-build/../.. \
+  && git pull -q \
+  && cd - \
+  && pyenv install 3.10.4 \
+  && pyenv global 3.10.4
+
+# Install tox
+pip3 install tox
+
+# Install poetry
+curl -fsS -o install-poetry.py https://install.python-poetry.org
+python3 install-poetry.py -y
+rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -50,14 +50,14 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
 
-git -C "/opt/circleci/.pyenv/" pull -q \
-  && pyenv install 3.10.4 \
-  && pyenv global 3.10.4
-
-# Install tox
-pip3 install tox
-
-# Install poetry
-curl -fsS -o install-poetry.py https://install.python-poetry.org
-python3 install-poetry.py
-rm install-poetry.py
+#git -C "/opt/circleci/.pyenv/" pull -q \
+#  && pyenv install 3.10.4 \
+#  && pyenv global 3.10.4
+#
+## Install tox
+#pip3 install tox
+#
+## Install poetry
+#curl -fsS -o install-poetry.py https://install.python-poetry.org
+#python3 install-poetry.py
+#rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -52,6 +52,10 @@ export PACHYDERM_VERSION="$(jq -r .pachyderm version.json)"
 curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v${PACHYDERM_VERSION}/pachctl_${PACHYDERM_VERSION}_amd64.deb
 sudo dpkg -i /tmp/pachctl.deb
 
+echo `which python3`
+echo `which python3.7`
+echo `which python3.10`
+
 # Install tox
 export PATH="/home/circleci/.local/bin:$PATH"
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -53,6 +53,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
+export PATH="/home/circleci/.local/bin:$PATH"
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 python3.10 -m pip install tox
 

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -53,6 +53,7 @@ sudo dpkg -i /tmp/pachctl.deb
 cd /opt/circleci/.pyenv/plugins/python-build/../.. \
   && git pull -q \
   && cd - \
+  && echo pwd \
   && pyenv install 3.10.4 \
   && pyenv global 3.10.4
 
@@ -60,6 +61,6 @@ cd /opt/circleci/.pyenv/plugins/python-build/../.. \
 pip3 install tox
 
 # Install poetry
-curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
-python3 install-poetry.py -y --version 1.1.8
+curl -fsS -o install-poetry.py https://install.python-poetry.org
+python3 install-poetry.py
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -53,7 +53,7 @@ sudo dpkg -i /tmp/pachctl.deb
 cd /opt/circleci/.pyenv/plugins/python-build/../.. \
   && git pull -q \
   && cd - \
-  && echo pwd \
+  && echo `pwd` \
   && pyenv install 3.10.4 \
   && pyenv global 3.10.4
 

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -60,6 +60,6 @@ cd /opt/circleci/.pyenv/plugins/python-build/../.. \
 pip3 install tox
 
 # Install poetry
-curl -fsS -o install-poetry.py https://install.python-poetry.org
-python3 install-poetry.py -y
+curl -fsS -o install-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/install-poetry.py
+python3 install-poetry.py -y --version 1.1.8
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -10,8 +10,6 @@ sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt update -y
 sudo apt-get install -y -qq \
   python3.7 \
-  python3.10 \
-  python3.10-distutils \
   python3.7-distutils \
   pkg-config \
   conntrack \
@@ -19,8 +17,11 @@ sudo apt-get install -y -qq \
   jq \
   socat
 
-cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
-pyenv install 3.10.4
+cd /opt/circleci/.pyenv/plugins/python-build/../.. \
+  && git pull \
+  && cd - \
+  && pyenv install 3.10.4 \
+  && pyenv global 3.10.4
 
 # Install Helm
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
@@ -58,11 +59,11 @@ sudo dpkg -i /tmp/pachctl.deb
 pyenv install 3.10.4
 
 # Install tox
-export PATH="/home/circleci/.local/bin:$PATH"
-curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-python3.10 -m pip install tox
+#export PATH="/home/circleci/.local/bin:$PATH"
+#curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+pip3 install tox
 
 # Install poetry
 curl -fsS -o install-poetry.py https://install.python-poetry.org
-python3.10 install-poetry.py -y
+python3 install-poetry.py -y
 rm install-poetry.py

--- a/etc/testing/circle/install.sh
+++ b/etc/testing/circle/install.sh
@@ -53,6 +53,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
 sudo dpkg -i /tmp/pachctl.deb
 
 # Install tox
+curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 python3.10 -m pip install tox
 
 # Install poetry

--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cat /home/circleci/project/poetry-installer-error-*.log
-
 echo "=== TEST FAILED OR TIMED OUT, DUMPING DEBUG INFO ==="
 
 export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH

--- a/etc/testing/circle/kube_debug.sh
+++ b/etc/testing/circle/kube_debug.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cat /home/circleci/project/poetry-installer-error-*.log
+
 echo "=== TEST FAILED OR TIMED OUT, DUMPING DEBUG INFO ==="
 
 export PATH=$(pwd):$(pwd)/cached-deps:$GOPATH/bin:$PATH

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,11 +41,11 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "betterproto"
-version = "2.0.0b3"
+version = "2.0.0b4"
 description = "A better Protobuf / gRPC generator & library"
 category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.6.2,<4.0"
 
 [package.dependencies]
 grpclib = ">=0.4.1,<0.5.0"
@@ -106,7 +106,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.1.2"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -182,7 +182,7 @@ testing = ["protobuf (>=3.6.0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.45.0"
+version = "1.46.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
@@ -192,18 +192,18 @@ python-versions = ">=3.6"
 six = ">=1.5.2"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.45.0)"]
+protobuf = ["grpcio-tools (>=1.46.0)"]
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.45.0"
+version = "1.46.0"
 description = "Standard Health Checking Service for gRPC"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-grpcio = ">=1.45.0"
+grpcio = ">=1.46.0"
 protobuf = ">=3.12.0"
 
 [[package]]
@@ -299,11 +299,11 @@ python-versions = "*"
 
 [[package]]
 name = "jinja2"
-version = "3.0.3"
+version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 MarkupSafe = ">=2.0"
@@ -411,15 +411,15 @@ python-versions = "*"
 
 [[package]]
 name = "numpydoc"
-version = "1.2.1"
+version = "1.3.1"
 description = "Sphinx extension to support docstrings in Numpy format"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-Jinja2 = ">=2.10,<3.1"
-sphinx = ">=1.8"
+Jinja2 = ">=2.10"
+sphinx = ">=3.0"
 
 [package.extras]
 testing = ["pytest", "pytest-cov", "matplotlib"]
@@ -472,7 +472,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.18.1"
+version = "2.19.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -865,7 +865,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "030535bbd58f77403955b829fe8f94c1d2b2f2c32ffd7b9589879aedaae3a7de"
+content-hash = "dae2536d4f5767225cf41f9cf2560da5627a0e3582ac4e242a48dc12269cd5b5"
 
 [metadata.files]
 alabaster = [
@@ -885,8 +885,8 @@ babel = [
     {file = "Babel-2.10.1.tar.gz", hash = "sha256:98aeaca086133efb3e1e2aad0396987490c8425929ddbcfe0550184fdc54cd13"},
 ]
 betterproto = [
-    {file = "betterproto-2.0.0b3-py3-none-any.whl", hash = "sha256:f2393a97ed8f70a0f1cb92f2590a1b0555267d0e971bc0a1d598fb564a2e7d2f"},
-    {file = "betterproto-2.0.0b3.tar.gz", hash = "sha256:1320de556289d8c825e1c28a9b3899030c653a0c8c0a7c0476b4dac5747dfec0"},
+    {file = "betterproto-2.0.0b4-py3-none-any.whl", hash = "sha256:6b807038df17a7896cc1f98b42f64eed24c2f350b6d10b2854501f8b9b7d3d1e"},
+    {file = "betterproto-2.0.0b4.tar.gz", hash = "sha256:99bc6f866fe9c30100fe438662439205f35bc0e65e4e736c46a6ebfea02c3e7b"},
 ]
 black = [
     {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
@@ -926,8 +926,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.1.2-py3-none-any.whl", hash = "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e"},
-    {file = "click-8.1.2.tar.gz", hash = "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -954,64 +954,64 @@ grpc-interceptor = [
     {file = "grpc_interceptor-0.13.2-py3-none-any.whl", hash = "sha256:c5cba4552514b83f29efe7f38c1e95b60d38aa1f87bc30f2223228a795e867e7"},
 ]
 grpcio = [
-    {file = "grpcio-1.45.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:0d74a159df9401747e57960f0772f4371486e3281919004efa9df8a82985abee"},
-    {file = "grpcio-1.45.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:4e6d15bfdfa28e5f6d524dd3b29c7dc129cfc578505b067aa97574490c5b70fe"},
-    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:44615be86e5540a18f5e4ca5a0f428d4b1efb800d255cfd9f902a11daca8fd74"},
-    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b452f715e2cae9e75cb309f59a37f82e5b25f51f0bfc3cd1462de86265cef05"},
-    {file = "grpcio-1.45.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db1c45daa35c64f17498af1ba6eb1d0a8d88a8a0b6b322f960ab461e7ef0419e"},
-    {file = "grpcio-1.45.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:678a673fe811dad3ed5bd2e2352b79851236e4d718aeaeffc10f372a55954d8d"},
-    {file = "grpcio-1.45.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a5c8a08aff0af770c977dcede62fbed53ae7b99adbc184d5299d148bb04652f1"},
-    {file = "grpcio-1.45.0-cp310-cp310-win32.whl", hash = "sha256:1d764c8a190719301ec6f3b6ddeb48a234604e337d0fbb3184a4ddcda2aca9da"},
-    {file = "grpcio-1.45.0-cp310-cp310-win_amd64.whl", hash = "sha256:797f5b750be6ff2905b9d0529a00c1f873d8035a5d01a9801910ace5f0d52a18"},
-    {file = "grpcio-1.45.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:b46772b7eb58c6cb0b468b56d59618694d2c2f2cee2e5b4e83ae9729a46b8af0"},
-    {file = "grpcio-1.45.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:2f135e5c8e9acd14f3090fd86dccb9d7c26aea7bfbd4528e8a86ff621d39e610"},
-    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:16603b9544a4af135ce4d594a7396602fbe62d1ccaa484b05cb1814c17a3e559"},
-    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ccba925045c00acc9ce2cc645b6fa9d19767dbb16c9c49921013da412b1d3415"},
-    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:7262b9d96db79e29049c7eb2b75b03f2b9485fd838209b5ff8e3cca73b2a706c"},
-    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1c1098f35c33b985c312cacea39e2aa66f7ac1462579eed1d3aed2e51fff00d"},
-    {file = "grpcio-1.45.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b18c86a9cfbedd0c4e083690fecc82027b3f938100ed0af8db77d52a171eb1e"},
-    {file = "grpcio-1.45.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:638364d3603df9e4a1dbc2151b5fe1b491ceecda4e1672be86724e1dfa79c44d"},
-    {file = "grpcio-1.45.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8de79eac582431cb6d05ff5652e68089c40aa0e604ec1630fa52ac926bc44f1b"},
-    {file = "grpcio-1.45.0-cp36-cp36m-win32.whl", hash = "sha256:6cf5f1827c182ef9b503d7d01e503c1067f4499d45af792d95ccd1d8b0bea30d"},
-    {file = "grpcio-1.45.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f1a22744f93b38d393b7a83cb607029ac5e2de680cab39957ffdd116590a178"},
-    {file = "grpcio-1.45.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:321f84dbc788481f7a3cd12636a133ba5f4d17e57f1c906de5a22fd709c971b5"},
-    {file = "grpcio-1.45.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:a33ed7d3e52ddc839e2f020592a4371d805c2ae820fb63b12525058e1810fe46"},
-    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9f28d8c5343602e1510d4839e38568bcd0ca6353bd98ad9941787584a371a1d"},
-    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3a40dbb8aac60cf6a86583e2ba74fc2c286f1abc7a3404b25dcd12a49b9f7d8b"},
-    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:b00ce58323dde47d2ea240d10ee745471b9966429c97d9e6567c8d56e02b0372"},
-    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd4944f35f1e5ab54804c3e37d24921ecc01908ef871cdce6bd52995ea4f985c"},
-    {file = "grpcio-1.45.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc135b77f384a84bac67a37947886986be136356446338d64160a30c85f20c6d"},
-    {file = "grpcio-1.45.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:35ae55460514ed404ceaa95533b9a79989691b562faf012fc8fb143d8fd16e47"},
-    {file = "grpcio-1.45.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:779db3d00c8da1d3efa942387cb0fea9ac6d50124d656024f82f9faefdd016e3"},
-    {file = "grpcio-1.45.0-cp37-cp37m-win32.whl", hash = "sha256:aea67bd3cbf93db552c725bc0b4db0acdc6a284d036d1cc32d638305e0f01fd9"},
-    {file = "grpcio-1.45.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7fe3ac700cc5ecba9dc9072c0e6cfd2f964ea9f273ce1111eaa27d13aa20ec32"},
-    {file = "grpcio-1.45.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:259c126821fefcda298c020a0d83c4a4edac3cf10b1af12a62d250f8192ea1d1"},
-    {file = "grpcio-1.45.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:5d05cd1b2b0975bb000ba97ca465565158dc211616c9bbbef5d1b77871974687"},
-    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6f2e044a715507fd13c70c928cd90daf8d0295c936a81fd9065a24e58ba7cc7d"},
-    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4d37c526b86c46d229f6117df5dca2510de597ab73c5956bc379ca41f8a1db84"},
-    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:6df338b8d2c328ba91a25e28786d10059dea3bc9115fa1ddad30ba5d459e714a"},
-    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:042921a824e90bf2974dbef7d89937096181298294799fb53e5576d9958884c7"},
-    {file = "grpcio-1.45.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb23ed6ed84ae312df03e96c7a7cd3aa5f7e3a1ad7066fdb6cd47f1bd334196c"},
-    {file = "grpcio-1.45.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:79582ec821ef10162348170a6e912d93ea257c749320a162dfc3a132ef25ac1b"},
-    {file = "grpcio-1.45.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d14d372ea5a51d5ab991aa6d499a26e5a1e3b3f3af93f41826ea610f8a276c9e"},
-    {file = "grpcio-1.45.0-cp38-cp38-win32.whl", hash = "sha256:b54444cf4212935a7b98cd26a30ad3a036389e4fd2ff3e461b176af876c7e20b"},
-    {file = "grpcio-1.45.0-cp38-cp38-win_amd64.whl", hash = "sha256:da395720d6e9599c754f862f3f75bc0e8ff29fa55259e082e442a9cc916ffbc3"},
-    {file = "grpcio-1.45.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:add03308fa2d434628aeaa445e0c75cdb9535f39128eb949b1483ae83fafade6"},
-    {file = "grpcio-1.45.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:250d8f18332f3dbd4db00efa91d33d336e58362e9c80e6946d45ecf5e82d95ec"},
-    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:dfca4dfd307b449d0a1e92bc7fbb5224ccf16db384aab412ba6766fc56bdffb6"},
-    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b7f2dc8831045eb0c892bb947e1cba2b1ed639e79a54abff7c4ad90bdd329f78"},
-    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:2355493a9e71f15d9004b2ab87892cb532e9e98db6882fced2912115eb5631af"},
-    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2798e42d62a0296982276d0bab96fc7d6772cd148357154348355304d6216763"},
-    {file = "grpcio-1.45.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fe6acb1439127e0bee773f8a9a3ece290cb4cac4fe8d46b10bc8dda250a990c"},
-    {file = "grpcio-1.45.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6774272a59b9ee16fb0d4f53e23716953a22bbb3efe12fdf9a4ee3eec2c4f81f"},
-    {file = "grpcio-1.45.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:52f61fcb17d92b87ba47d54b3c9deae09d4f0216a3ea277b7df4b6c1794e6556"},
-    {file = "grpcio-1.45.0-cp39-cp39-win32.whl", hash = "sha256:3992c690228126e5652c7a1f61863c1ebfd71369cf2adb0fce86fee1d82d2d27"},
-    {file = "grpcio-1.45.0-cp39-cp39-win_amd64.whl", hash = "sha256:220867a53e53b2e201e98c55061e3053e31c0ce613625087242be684d3e8612a"},
-    {file = "grpcio-1.45.0.tar.gz", hash = "sha256:ff2c8b965b0fc25cf281961aa46619c10900543effe3f806ef818231c40aaff3"},
+    {file = "grpcio-1.46.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fa4834022ca45fcde57fabcd12e5458fdb01372c4c8ab84030eabec24c6f39ca"},
+    {file = "grpcio-1.46.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:bdad8c088e088e5d34e9c10a5db8871157cc1a7e42f49ea4bd320fd8b57e7eb2"},
+    {file = "grpcio-1.46.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:9e70290273b9d7e6d1cd8f8a7a621c4e9a91a3a35be3068610ee014124a35e75"},
+    {file = "grpcio-1.46.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cbfc0c85a2eb34de711028fe9630b159a1c0df5580359368bff8429596c56c97"},
+    {file = "grpcio-1.46.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2fe454b7dd4c41a9cb8fbbb18474fd9a2f7935ac203b5f47a00216beec8aacd"},
+    {file = "grpcio-1.46.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:666d40de9e323392f985921c4d112ebda8decd7a4532b9524f7e6f6fd5e4ca57"},
+    {file = "grpcio-1.46.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:668cc3e277f2bb88189bb4f0d7dfece326be789096660f94553600040630969c"},
+    {file = "grpcio-1.46.0-cp310-cp310-win32.whl", hash = "sha256:80aa6247a77cba60b56192df57cc5d78f0e2fe697fc6ebdf089ce93df894db3e"},
+    {file = "grpcio-1.46.0-cp310-cp310-win_amd64.whl", hash = "sha256:828078cb73008c65794af94201c975610d16c9440b00e5efefc9e45dd23de73b"},
+    {file = "grpcio-1.46.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:4be2d7f283a7e2a15f9c5d70e1c9899e1824ea0650dbd82b7dc5e54d0c8061a5"},
+    {file = "grpcio-1.46.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:6ab4aeadc6c76447bcae91da1c69eeff9d0b78af7051fdcebe18a4cdf766f727"},
+    {file = "grpcio-1.46.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c8c0eaede86ae97213548633eb07446dab75a48c771ad8bb3751bffbd9055ea9"},
+    {file = "grpcio-1.46.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b45f4f0815e1df26ced52e6e7012055d023d1b2d943e5d3d168e211bdbb823ad"},
+    {file = "grpcio-1.46.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:63e827caff24f7d02c2d4d6fbca720001f7e5158a68abba37ea0c7eb447adfe5"},
+    {file = "grpcio-1.46.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c6958a8a6a8df1caa536314bda3fb54f9ca5c936c14e3a486ff51d150c342c7"},
+    {file = "grpcio-1.46.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edc0e052d349d7bac6719bddb5e779314b060eca1f53f99e0cc0be1aea66285a"},
+    {file = "grpcio-1.46.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d2b99b28b75b1929d92d947b74b7c74610131ac6acf803f2dedde7d245bc8b90"},
+    {file = "grpcio-1.46.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:518b3294dcdd734c4551a7c4cf3b457b9e0b949f4d855419600ceb7921de6f00"},
+    {file = "grpcio-1.46.0-cp36-cp36m-win32.whl", hash = "sha256:eca51dd5d16b3a6b19c255cbcb236387d5cc9e058faeff024cd0c904d16f2495"},
+    {file = "grpcio-1.46.0-cp36-cp36m-win_amd64.whl", hash = "sha256:206becfce3ad377f50c934b4d91f3fd5f101fe71db80ccce800d6bb898605448"},
+    {file = "grpcio-1.46.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:c95497d9bf93c8553b558646dd61cb4b15269c28fcee1a8843892edd50f3754f"},
+    {file = "grpcio-1.46.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:fed35c01a01c6d050f8d67456dad83b5196bf4aff6d88fadd9b70936fb732826"},
+    {file = "grpcio-1.46.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1419ab58c830f2da40884f4e1b4583038b12d6609fcac1a5700eff9ca9a75070"},
+    {file = "grpcio-1.46.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:65477bb9e884c9f46cde27c083d69c6588342f24ee5d56bbf731b9a4a14cc781"},
+    {file = "grpcio-1.46.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:d5ef9194f9bc216c8d0c18885bb7db247b0018a219ded543a6a6c2fe9454b220"},
+    {file = "grpcio-1.46.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed29cc8cb0394cb5ae9cf0a56e32228e9d98b8bb79a088393a18346510a06132"},
+    {file = "grpcio-1.46.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e4972b82ee1164eeee297e86a6351a2f358e1a9e5b65ae491a7a140d276cec4"},
+    {file = "grpcio-1.46.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9ab12c5bfb13f294f6215a2580e446396eaac1b101e6cdb74d7bea3c6be3143e"},
+    {file = "grpcio-1.46.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c1111369863d04ea49378b73c1c2890bafa4c558c9cf799da52bf922483c8a3c"},
+    {file = "grpcio-1.46.0-cp37-cp37m-win32.whl", hash = "sha256:653d69bc4ac2e1f1bf36625aa42fbba8d399df609ded69a74b5820ca995e75dd"},
+    {file = "grpcio-1.46.0-cp37-cp37m-win_amd64.whl", hash = "sha256:afe8cbd4ed74f7d955c7732195d5f46c6af7b0867dfe642c8628332585fa40ee"},
+    {file = "grpcio-1.46.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:2f59d6beb12bbccd3d1ecd23d78f0f1a63324cddc42c744c6d13abeef6039496"},
+    {file = "grpcio-1.46.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:170ade19379157d5c8e01c8176858a7ffbbf904b7896917c323134021afc1926"},
+    {file = "grpcio-1.46.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a6d45e6fbe3f60fa3a8907f55e8d626a4aa452eb108edfa7f533c9161d973ef9"},
+    {file = "grpcio-1.46.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:47f0c0820d0b7f6e4930729b9067f346a07d4bbc632d109a2bcc7ca6f260c5f1"},
+    {file = "grpcio-1.46.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:b3004fd04bfd3dba17f9d28b094bff76a32d7e85408f9f26f02594aa31fba040"},
+    {file = "grpcio-1.46.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4d4a17d8afcd6c9e4f06cf52b3f7ce0ca06f33510a47358848d30a1aebef10b"},
+    {file = "grpcio-1.46.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbfac305c16cb5fcff894f3b80923863877584f1d3be66164aa218ed32841bcb"},
+    {file = "grpcio-1.46.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d518477a73b467953ac8cff08022394b5250e8cfd7adfd167f76fd2d76969158"},
+    {file = "grpcio-1.46.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2a751c533679dbc0194daf91a6e665d6163f9b423fc6f2e506035ddc17118f9d"},
+    {file = "grpcio-1.46.0-cp38-cp38-win32.whl", hash = "sha256:20fde26fbd40547c65817ca47b15f1f51d4bb0a70fd8a836fa08c9ad9b284b03"},
+    {file = "grpcio-1.46.0-cp38-cp38-win_amd64.whl", hash = "sha256:70b6d401a758e85318a2be038eccf8ab965a14082b9f89152f19b8f9b7ac762e"},
+    {file = "grpcio-1.46.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:c8539a82debdd50c7fe3f0565b36b5efcd6a68f30ab635aced4175569d5f45e2"},
+    {file = "grpcio-1.46.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:884b0182d89bb934a5615f9d056df44e8681473cd124e6262382b5888353691b"},
+    {file = "grpcio-1.46.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:26ab8415e2e048e32cf05a86e7b6d76864bc018f837a93112c177130c2743766"},
+    {file = "grpcio-1.46.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e30a1be3d1ec426f32d6fa22d9af9f5169a40d4b0955ce1fb111e869e0c0f44f"},
+    {file = "grpcio-1.46.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:7c4fff11237fee6f07ac6937f2cff02a1f28d8bf2d675d1c57496423ddb8e01f"},
+    {file = "grpcio-1.46.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19646d7d51643231fbd3414134ddbf5c4c226db861a800bc8c04ac870533b614"},
+    {file = "grpcio-1.46.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1efd92661c4d4b106cd97025d52a480255b387ba75d3070cee6c4677e375f1c5"},
+    {file = "grpcio-1.46.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9e7ea7a8e7521664dd630fab35daab106a490b65e29254f90aeac66ec5cf1f68"},
+    {file = "grpcio-1.46.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bd58caa70b4228ebb31e1b5c9872053f9fde4412ef69a1be65b8a8eaae8cf072"},
+    {file = "grpcio-1.46.0-cp39-cp39-win32.whl", hash = "sha256:4befe75c0122fe51ae046a4936b735c306ea63849405cd8dc0be534affd60ea0"},
+    {file = "grpcio-1.46.0-cp39-cp39-win_amd64.whl", hash = "sha256:25cf4ede6f9703913b4381969159452ff6ca5dfb93d5f58b80d1763e9ad79b18"},
+    {file = "grpcio-1.46.0.tar.gz", hash = "sha256:ef37ff444d248ff8ea5e175a7807ce19e324831bc00d466169191cd9aad0ee36"},
 ]
 grpcio-health-checking = [
-    {file = "grpcio-health-checking-1.45.0.tar.gz", hash = "sha256:765e26d9cdec6717a73cd89eca8b723f13fc9bea0a6ded9b6c9f5a388ad3554b"},
-    {file = "grpcio_health_checking-1.45.0-py3-none-any.whl", hash = "sha256:33a3b72e468c582edaed77463d09f106d9ff86a5d9996560632244dad99d2374"},
+    {file = "grpcio-health-checking-1.46.0.tar.gz", hash = "sha256:aff328b8c4f3ac1cee93a5db5dcdf68f1e4b0ca23e64e0bd0dc87fde918e3aa3"},
+    {file = "grpcio_health_checking-1.46.0-py3-none-any.whl", hash = "sha256:593127c02bb016caf10636f7ddac5317edec7cecbebceaece80b8f9888950707"},
 ]
 grpclib = [
     {file = "grpclib-0.4.2.tar.gz", hash = "sha256:ead080cb7d56d6a5e835aaf5255d1ef1dce475a7722566ea225f0188fce33b68"},
@@ -1049,8 +1049,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
-    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-1.1.0.tar.gz", hash = "sha256:36be6bb3ad987bfdb839f5ba78ddf094552ca38ccbd784ae4f74a4e1419fc6e3"},
@@ -1180,8 +1180,8 @@ nodeenv = [
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 numpydoc = [
-    {file = "numpydoc-1.2.1-py3-none-any.whl", hash = "sha256:2d317df5fd9404a5199bb993c1b6627436b2804582d2775bf9ccf3c5912ebe99"},
-    {file = "numpydoc-1.2.1.tar.gz", hash = "sha256:7ce826ed0d54c3fdc9097992a8d73a4d459dc468611351c68e444fec44a45af6"},
+    {file = "numpydoc-1.3.1-py3-none-any.whl", hash = "sha256:a49822cb225e71b7ef7889dd42576b5aa14c56ce62e0bc030f97abc8a3ae240f"},
+    {file = "numpydoc-1.3.1.tar.gz", hash = "sha256:349ff29e00a5caf119141967e579f8f17b24d41c46740b13ea4e8dba9971b20f"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -1200,8 +1200,8 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.18.1-py2.py3-none-any.whl", hash = "sha256:02226e69564ebca1a070bd1f046af866aa1c318dbc430027c50ab832ed2b73f2"},
-    {file = "pre_commit-2.18.1.tar.gz", hash = "sha256:5d445ee1fa8738d506881c5d84f83c62bb5be6b2838e32207433647e8e5ebe10"},
+    {file = "pre_commit-2.19.0-py2.py3-none-any.whl", hash = "sha256:10c62741aa5704faea2ad69cb550ca78082efe5697d6f04e5710c3c229afdd10"},
+    {file = "pre_commit-2.19.0.tar.gz", hash = "sha256:4233a1e38621c87d9dda9808c6606d7e7ba0e087cd56d3fe03202a01d2919615"},
 ]
 protobuf = [
     {file = "protobuf-3.20.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3cc797c9d15d7689ed507b165cd05913acb992d78b379f6014e013f9ecb20996"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ grpcio-health-checking = ">=1.38.0"
 grpc-interceptor = "^0.13.0"
 importlib-metadata = { version = ">1.5.1", python = "<3.8" }
 protobuf = ">=3.17.1"
-betterproto = "2.0.0b3"
+betterproto = "2.0.0b4"
 
 [tool.poetry.dev-dependencies]
 black = ">=21.5b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ force-exclude = '''
 '''
 
 [build-system]
-requires = ["setuptools", "poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py39, lint, examples
+envlist = py37, py310, lint, examples
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
For some reason the installing python3.10 through `apt` broke CI, so I had to do some research on how on a more sustainable method for testing python on circleci. The major changes were:
* using `pyenv` to install the python version used for testing
* abandon `tox` for CI (it's still a dev dependency and referenced in the contributor readme, but it can be fully removed if you think it no longer is useful)
* rearrange the circleCI config to make it more extensible and easier to perform these updates in the future
* Also had to bump `betterproto` version for python3.10 compatibility.

Let me know what you think