### PR TITLE
revert breaking change

### DIFF
--- a/src/python_pachyderm/mixin/pfs.py
+++ b/src/python_pachyderm/mixin/pfs.py
@@ -914,6 +914,8 @@ class PFSMixin:
         """
         message = pfs_pb2.GetFileRequest(
             file=pfs_pb2.File(commit=commit_from(commit), path=path, datum=datum),
+            URL=URL,
+            offset=offset,
         )
         stream = self.__stub.GetFile(message)
         return PFSFile(stream)


### PR DESCRIPTION
Fix a breaking change to the `Client.get_file` method which silently ignored the `URL` and `offset` arguments.

closes: #410 