### PR TITLE
Project support bugs - PPS Mixin

### DIFF
--- a/src/python_pachyderm/experimental/mixin/pfs.py
+++ b/src/python_pachyderm/experimental/mixin/pfs.py
@@ -183,7 +183,7 @@ class PFSMixin:
         pfs_proto.ProjectInfo
             A protobuf object with info on the project.
         """
-        self._req(
+        return self._req(
             Service.PFS, "InspectProject", project=pfs_proto.Project(name=project_name)
         )
 
@@ -195,7 +195,7 @@ class PFSMixin:
         Iterator[pfs_proto.ProjectInfo]
             An iterator of protobuf objects that contain info on a project.
         """
-        self._req(
+        return self._req(
             Service.PFS,
             "ListProject",
             req=bp_proto.Empty(),

--- a/src/python_pachyderm/experimental/mixin/pps.py
+++ b/src/python_pachyderm/experimental/mixin/pps.py
@@ -68,7 +68,8 @@ class PPSMixin:
                         "InspectJob",
                         job=pps_proto.Job(
                             pipeline=pps_proto.Pipeline(
-                                name=pipeline_name, project=project_name
+                                name=pipeline_name,
+                                project=pfs_proto.Project(name=project_name),
                             ),
                             id=job_id,
                         ),
@@ -168,7 +169,9 @@ class PPSMixin:
             return self._req(
                 Service.PPS,
                 "ListJob",
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 input_commit=input_commit,
                 history=history,
                 details=details,
@@ -207,7 +210,9 @@ class PPSMixin:
             Service.PPS,
             "DeleteJob",
             job=pps_proto.Job(
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 id=job_id,
             ),
         )
@@ -236,7 +241,9 @@ class PPSMixin:
             Service.PPS,
             "StopJob",
             job=pps_proto.Job(
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 id=job_id,
             ),
             reason=reason,
@@ -270,7 +277,7 @@ class PPSMixin:
                 id=datum_id,
                 job=pps_proto.Job(
                     pipeline=pps_proto.Pipeline(
-                        name=pipeline_name, project=project_name
+                        name=pipeline_name, project=pfs_proto.Project(name=project_name)
                     ),
                     id=job_id,
                 ),
@@ -346,7 +353,7 @@ class PPSMixin:
                 "ListDatum",
                 job=pps_proto.Job(
                     pipeline=pps_proto.Pipeline(
-                        name=pipeline_name, project=project_name
+                        name=pipeline_name, project=pfs_proto.Project(name=project_name)
                     ),
                     id=job_id,
                 ),
@@ -385,7 +392,9 @@ class PPSMixin:
             Service.PPS,
             "RestartDatum",
             job=pps_proto.Job(
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 id=job_id,
             ),
             data_filters=data_filters,
@@ -520,7 +529,9 @@ class PPSMixin:
         self._req(
             Service.PPS,
             "CreatePipeline",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
             transform=transform,
             parallelism_spec=parallelism_spec,
             egress=egress,
@@ -610,7 +621,8 @@ class PPSMixin:
                         Service.PPS,
                         "InspectPipeline",
                         pipeline=pps_proto.Pipeline(
-                            name=pipeline_name, project=project_name
+                            name=pipeline_name,
+                            project=pfs_proto.Project(name=project_name),
                         ),
                         details=details,
                     )
@@ -622,7 +634,9 @@ class PPSMixin:
             return self._req(
                 Service.PPS,
                 "ListPipeline",
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 history=history,
                 details=details,
             )
@@ -703,7 +717,9 @@ class PPSMixin:
         self._req(
             Service.PPS,
             "DeletePipeline",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
             force=force,
             keep_repo=keep_repo,
         )
@@ -729,7 +745,9 @@ class PPSMixin:
         self._req(
             Service.PPS,
             "StartPipeline",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
         )
 
     def stop_pipeline(self, pipeline_name: str, project_name: str = None) -> None:
@@ -745,7 +763,9 @@ class PPSMixin:
         self._req(
             Service.PPS,
             "StopPipeline",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
         )
 
     def run_cron(self, pipeline_name: str, project_name: str = None) -> None:
@@ -764,7 +784,9 @@ class PPSMixin:
         self._req(
             Service.PPS,
             "RunCron",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
         )
 
     def create_secret(
@@ -905,7 +927,9 @@ class PPSMixin:
         return self._req(
             Service.PPS,
             "GetLogs",
-            pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_proto.Pipeline(
+                name=pipeline_name, project=pfs_proto.Project(name=project_name)
+            ),
             data_filters=data_filters,
             master=master,
             datum=datum,
@@ -969,7 +993,9 @@ class PPSMixin:
             Service.PPS,
             "GetLogs",
             job=pps_proto.Job(
-                pipeline=pps_proto.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_proto.Pipeline(
+                    name=pipeline_name, project=pfs_proto.Project(name=project_name)
+                ),
                 id=job_id,
             ),
             data_filters=data_filters,

--- a/src/python_pachyderm/mixin/pps.py
+++ b/src/python_pachyderm/mixin/pps.py
@@ -67,7 +67,10 @@ class PPSMixin:
             message = pps_pb2.InspectJobRequest(
                 details=details,
                 job=pps_pb2.Job(
-                    pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                    pipeline=pps_pb2.Pipeline(
+                        name=pipeline_name,
+                        project=pfs_pb2.Project(name=project_name),
+                    ),
                     id=job_id,
                 ),
                 wait=wait,
@@ -200,7 +203,9 @@ class PPSMixin:
         message = pps_pb2.DeleteJobRequest(
             job=pps_pb2.Job(
                 id=job_id,
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                ),
             )
         )
         self.__stub.DeleteJob(message)
@@ -228,7 +233,10 @@ class PPSMixin:
         message = pps_pb2.StopJobRequest(
             job=pps_pb2.Job(
                 id=job_id,
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name,
+                    project=pfs_pb2.Project(name=project_name),
+                ),
             ),
             reason=reason,
         )
@@ -260,7 +268,9 @@ class PPSMixin:
                 id=datum_id,
                 job=pps_pb2.Job(
                     id=job_id,
-                    pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                    pipeline=pps_pb2.Pipeline(
+                        name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                    ),
                 ),
             ),
         )
@@ -332,7 +342,9 @@ class PPSMixin:
         if pipeline_name is not None and job_id is not None:
             message.job.CopyFrom(
                 pps_pb2.Job(
-                    pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                    pipeline=pps_pb2.Pipeline(
+                        name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                    ),
                     id=job_id,
                 )
             )
@@ -364,7 +376,9 @@ class PPSMixin:
         message = pps_pb2.RestartDatumRequest(
             data_filters=data_filters,
             job=pps_pb2.Job(
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                ),
                 id=job_id,
             ),
         )
@@ -584,7 +598,9 @@ class PPSMixin:
         if history == 0:
             message = pps_pb2.InspectPipelineRequest(
                 details=details,
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                ),
             )
             return iter([self.__stub.InspectPipeline(message)])
         else:
@@ -593,7 +609,9 @@ class PPSMixin:
             message = pps_pb2.ListPipelineRequest(
                 details=details,
                 history=history,
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                ),
             )
             return self.__stub.ListPipeline(message)
 
@@ -672,7 +690,9 @@ class PPSMixin:
         message = pps_pb2.DeletePipelineRequest(
             force=force,
             keep_repo=keep_repo,
-            pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_pb2.Pipeline(
+                name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+            ),
         )
         self.__stub.DeletePipeline(message)
 
@@ -692,7 +712,9 @@ class PPSMixin:
             The name of the project.
         """
         message = pps_pb2.StartPipelineRequest(
-            pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_pb2.Pipeline(
+                name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+            ),
         )
         self.__stub.StartPipeline(message)
 
@@ -707,7 +729,9 @@ class PPSMixin:
             The name of the project.
         """
         message = pps_pb2.StopPipelineRequest(
-            pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name)
+            pipeline=pps_pb2.Pipeline(
+                name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+            )
         )
         self.__stub.StopPipeline(message)
 
@@ -725,7 +749,9 @@ class PPSMixin:
             The name of the project.
         """
         message = pps_pb2.RunCronRequest(
-            pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+            pipeline=pps_pb2.Pipeline(
+                name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+            ),
         )
         self.__stub.RunCron(message)
 
@@ -931,7 +957,9 @@ class PPSMixin:
         """
         message = pps_pb2.GetLogsRequest(
             job=pps_pb2.Job(
-                pipeline=pps_pb2.Pipeline(name=pipeline_name, project=project_name),
+                pipeline=pps_pb2.Pipeline(
+                    name=pipeline_name, project=pfs_pb2.Project(name=project_name)
+                ),
                 id=job_id,
             ),
             data_filters=data_filters,

--- a/tests/experimental/test_pfs.py
+++ b/tests/experimental/test_pfs.py
@@ -47,6 +47,33 @@ def test_delete_non_existent_repo():
     assert len(list(client.list_repo())) == orig_repo_count
 
 
+def test_list_project():
+    client, repo_name = sandbox("list_project")
+    project_name = f"test_list_project-{repo_name}"
+    client.create_project(project_name)
+    projects = list(client.list_project())
+    assert len(projects) >= 1
+    assert project_name in [r.project.name for r in projects]
+
+
+def test_inspect_project():
+    client, repo_name = sandbox("inspect_repo")
+    project_name = f"test_inspect_project-{repo_name}"
+    client.create_project(project_name)
+    r = client.inspect_project(project_name)
+    assert r.project.name == project_name
+
+
+def test_delete_project():
+    client, repo_name = sandbox("delete_repo")
+    project_name = f"test_delete_project-{repo_name}"
+    client.create_project(project_name)
+    orig_project_count = len(list(client.list_project()))
+    assert orig_project_count >= 1
+    client.delete_project(project_name)
+    assert len(list(client.list_project())) == orig_project_count - 1
+
+
 def test_delete_all_repos():
     client = python_pachyderm.experimental.Client()
 

--- a/tests/experimental/test_pps.py
+++ b/tests/experimental/test_pps.py
@@ -272,11 +272,10 @@ def test_secrets():
 
 
 def test_get_pipeline_logs():
-    sandbox = Sandbox("get_pipeline_logs")
+    sandbox = Sandbox("pipeline_logs")
     sandbox.wait()
 
     # Just make sure these spit out some logs
-    print(f"pipeline: {sandbox.pipeline_repo_name}")
     logs = sandbox.client.get_pipeline_logs(
         sandbox.pipeline_repo_name, project_name=sandbox.project_name, follow=True
     )
@@ -294,12 +293,14 @@ def test_get_pipeline_logs():
 
 
 def test_get_job_logs():
-    sandbox = Sandbox("get_logs_logs")
+    sandbox = Sandbox("get_job_logs")
     job_id = sandbox.wait()
     pipeline_name = sandbox.pipeline_repo_name
 
     # Wait for the job to complete
-    commit = (pipeline_name, job_id)
+    commit = python_pachyderm.experimental.pfs.Commit(
+        repo=pipeline_name, id=job_id, project=sandbox.project_name
+    )
     sandbox.client.wait_commit(commit)
 
     # Just make sure these spit out some logs

--- a/tests/experimental/test_pps.py
+++ b/tests/experimental/test_pps.py
@@ -193,14 +193,10 @@ def test_list_pipeline():
 def test_delete_pipeline():
     sandbox = Sandbox("delete_pipeline")
     orig_pipeline_count = len(list(sandbox.client.list_pipeline()))
-    try:
-        sandbox.client.delete_pipeline(
-            sandbox.pipeline_repo_name, project_name=sandbox.project_name
-        )
-    except grpc.RpcError:
-        sandbox.client.delete_pipeline(
-            sandbox.pipeline_repo_name, project_name=sandbox.project_name
-        )
+    time.sleep(1)
+    sandbox.client.delete_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
     assert len(list(sandbox.client.list_pipeline())) == orig_pipeline_count - 1
 
 

--- a/tests/experimental/test_pps.py
+++ b/tests/experimental/test_pps.py
@@ -40,12 +40,17 @@ def test_list_subjob():
     jobs = list(sandbox.client.list_job())
     assert len(jobs) >= 1
 
-    jobs = list(sandbox.client.list_job(pipeline_name=sandbox.pipeline_repo_name))
+    jobs = list(
+        sandbox.client.list_job(
+            pipeline_name=sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )
     assert len(jobs) >= 1
 
     jobs = list(
         sandbox.client.list_job(
             pipeline_name=sandbox.pipeline_repo_name,
+            project_name=sandbox.project_name,
             input_commit=dict(
                 repo=sandbox.input_repo_name,
                 id=sandbox.commit.id,
@@ -72,7 +77,11 @@ def test_inspect_subjob():
     sandbox = Sandbox("inspect_subjob")
     job_id = sandbox.wait()
 
-    job_info = list(sandbox.client.inspect_job(job_id, sandbox.pipeline_repo_name))
+    job_info = list(
+        sandbox.client.inspect_job(
+            job_id, sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )
     assert job_info[0].job.id == job_id
 
 
@@ -96,13 +105,17 @@ def test_stop_job():
     pipeline_name = sandbox.pipeline_repo_name
     job_id = sandbox.wait()
 
-    sandbox.client.stop_job(job_id, pipeline_name)
+    sandbox.client.stop_job(job_id, pipeline_name, project_name=sandbox.project_name)
     # This is necessary because `StopJob` does not wait for the job to be
     # killed before returning a result.
     # TODO: remove once this is fixed:
     # https://github.com/pachyderm/pachyderm/issues/3856
     time.sleep(1)
-    job_info = list(sandbox.client.inspect_job(job_id, pipeline_name))
+    job_info = list(
+        sandbox.client.inspect_job(
+            job_id, pipeline_name, project_name=sandbox.project_name
+        )
+    )
     # We race to stop the job before it finishes - if we lose the race, it will
     # be in state JOB_SUCCESS
     assert job_info[0].state in [
@@ -115,7 +128,9 @@ def test_delete_job():
     sandbox = Sandbox("delete_job")
     job_id = sandbox.wait()
     orig_job_count = len(list(sandbox.client.list_job()))
-    sandbox.client.delete_job(job_id, sandbox.pipeline_repo_name)
+    sandbox.client.delete_job(
+        job_id, sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
     jobs = len(list(sandbox.client.list_job()))
     assert jobs == orig_job_count - 1
 
@@ -128,9 +143,15 @@ def test_datums():
     # flush the job so it fully finishes
     list(sandbox.client.wait_commit(sandbox.commit.id))
 
-    datums = list(sandbox.client.list_datum(pipeline_name, job_id))
+    datums = list(
+        sandbox.client.list_datum(
+            pipeline_name, job_id, project_name=sandbox.project_name
+        )
+    )
     assert len(datums) == 1
-    datum = sandbox.client.inspect_datum(pipeline_name, job_id, datums[0].datum.id)
+    datum = sandbox.client.inspect_datum(
+        pipeline_name, job_id, datums[0].datum.id, project_name=sandbox.project_name
+    )
     assert datum.state == pps_proto.DatumState.SUCCESS
 
     with pytest.raises(
@@ -139,15 +160,23 @@ def test_datums():
             job_id
         ),
     ):
-        sandbox.client.restart_datum(pipeline_name, job_id)
+        sandbox.client.restart_datum(
+            pipeline_name, job_id, project_name=sandbox.project_name
+        )
 
 
 def test_inspect_pipeline():
     sandbox = Sandbox("inspect_pipeline")
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert pipeline.pipeline.name == sandbox.pipeline_repo_name
     pipelines = list(
-        sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name, history=-1)
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name, history=-1
+        )
     )
     assert sandbox.pipeline_repo_name in [p.pipeline.name for p in pipelines]
 
@@ -163,7 +192,9 @@ def test_list_pipeline():
 def test_delete_pipeline():
     sandbox = Sandbox("delete_pipeline")
     orig_pipeline_count = len(list(sandbox.client.list_pipeline()))
-    sandbox.client.delete_pipeline(sandbox.pipeline_repo_name)
+    sandbox.client.delete_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
     assert len(list(sandbox.client.list_pipeline())) == orig_pipeline_count - 1
 
 
@@ -177,12 +208,24 @@ def test_delete_all_pipelines():
 def test_restart_pipeline():
     sandbox = Sandbox("restart_job")
 
-    sandbox.client.stop_pipeline(sandbox.pipeline_repo_name)
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    sandbox.client.stop_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert pipeline.stopped
 
-    sandbox.client.start_pipeline(sandbox.pipeline_repo_name)
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    sandbox.client.start_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert not pipeline.stopped
 
 
@@ -196,7 +239,9 @@ def test_run_cron():
     # cron input
     # NOTE: `e` is used after the context
     with pytest.raises(python_pachyderm.RpcError, match=r"pipeline.*have a cron input"):
-        sandbox.client.run_cron(sandbox.pipeline_repo_name)
+        sandbox.client.run_cron(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
 
 
 def test_secrets():
@@ -232,12 +277,17 @@ def test_get_pipeline_logs():
 
     # Just make sure these spit out some logs
     print(f"pipeline: {sandbox.pipeline_repo_name}")
-    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name, follow=True)
+    logs = sandbox.client.get_pipeline_logs(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name, follow=True
+    )
     assert next(logs) is not None
     del logs
 
     logs = sandbox.client.get_pipeline_logs(
-        sandbox.pipeline_repo_name, master=True, follow=True
+        sandbox.pipeline_repo_name,
+        project_name=sandbox.project_name,
+        master=True,
+        follow=True,
     )
     assert next(logs) is not None
     del logs
@@ -253,7 +303,9 @@ def test_get_job_logs():
     sandbox.client.wait_commit(commit)
 
     # Just make sure these spit out some logs
-    logs = sandbox.client.get_job_logs(pipeline_name, job_id, follow=True)
+    logs = sandbox.client.get_job_logs(
+        pipeline_name, job_id, project_name=sandbox.project_name, follow=True
+    )
     assert next(logs) is not None
     del logs
 

--- a/tests/experimental/test_pps.py
+++ b/tests/experimental/test_pps.py
@@ -4,6 +4,7 @@
 
 import time
 
+import grpc
 import pytest
 
 import python_pachyderm
@@ -192,9 +193,14 @@ def test_list_pipeline():
 def test_delete_pipeline():
     sandbox = Sandbox("delete_pipeline")
     orig_pipeline_count = len(list(sandbox.client.list_pipeline()))
-    sandbox.client.delete_pipeline(
-        sandbox.pipeline_repo_name, project_name=sandbox.project_name
-    )
+    try:
+        sandbox.client.delete_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    except grpc.RpcError:
+        sandbox.client.delete_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
     assert len(list(sandbox.client.list_pipeline())) == orig_pipeline_count - 1
 
 

--- a/tests/experimental/util.py
+++ b/tests/experimental/util.py
@@ -78,16 +78,13 @@ def create_test_pipeline(client: python_pachyderm.Client, test_name):
 
     client.create_pipeline(
         pipeline_repo_name,
+        project_name=project_name,
         transform=pps_proto.Transform(
             cmd=["sh"],
             image="alpine",
             stdin=["cp /pfs/{}/*.dat /pfs/out/".format(input_repo_name)],
         ),
-        input=pps_proto.Input(
-            pfs=pps_proto.PfsInput(
-                glob="/*", repo=input_repo_name, project=project_name
-            )
-        ),
+        input=pps_proto.Input(pfs=pps_proto.PfsInput(glob="/*", repo=input_repo_name)),
     )
 
     with client.commit(input_repo_name, "master", project_name=project_name) as commit:

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -50,6 +50,33 @@ def test_delete_non_existent_repo():
     assert len(list(client.list_repo())) == orig_repo_count
 
 
+def test_list_project():
+    client, repo_name = sandbox("list_project")
+    project_name = f"test_list_project-{repo_name}"
+    client.create_project(project_name)
+    projects = list(client.list_project())
+    assert len(projects) >= 1
+    assert project_name in [r.project.name for r in projects]
+
+
+def test_inspect_project():
+    client, repo_name = sandbox("inspect_repo")
+    project_name = f"test_inspect_project-{repo_name}"
+    client.create_project(project_name)
+    r = client.inspect_project(project_name)
+    assert r.project.name == project_name
+
+
+def test_delete_project():
+    client, repo_name = sandbox("delete_repo")
+    project_name = f"test_delete_project-{repo_name}"
+    client.create_project(project_name)
+    orig_project_count = len(list(client.list_project()))
+    assert orig_project_count >= 1
+    client.delete_project(project_name)
+    assert len(list(client.list_project())) == orig_project_count - 1
+
+
 def test_delete_all_repos():
     client = python_pachyderm.Client()
 

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -283,7 +283,7 @@ def test_secrets():
 
 
 def test_get_pipeline_logs():
-    sandbox = Sandbox("get_pipeline_logs")
+    sandbox = Sandbox("pipeline_logs")
     sandbox.wait()
 
     # Just make sure these spit out some logs
@@ -304,12 +304,14 @@ def test_get_pipeline_logs():
 
 
 def test_get_job_logs():
-    sandbox = Sandbox("get_logs_logs")
+    sandbox = Sandbox("get_job_logs")
     job_id = sandbox.wait()
     pipeline_name = sandbox.pipeline_repo_name
 
     # Wait for the job to complete
-    commit = (pipeline_name, job_id)
+    commit = python_pachyderm.pfs.Commit(
+        repo=pipeline_name, id=job_id, project=sandbox.project_name
+    )
     sandbox.client.wait_commit(commit)
 
     # Just make sure these spit out some logs

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -38,12 +38,17 @@ def test_list_subjob():
     jobs = list(sandbox.client.list_job())
     assert len(jobs) >= 1
 
-    jobs = list(sandbox.client.list_job(pipeline_name=sandbox.pipeline_repo_name))
+    jobs = list(
+        sandbox.client.list_job(
+            pipeline_name=sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )
     assert len(jobs) >= 1
 
     jobs = list(
         sandbox.client.list_job(
             pipeline_name=sandbox.pipeline_repo_name,
+            project_name=sandbox.project_name,
             input_commit=dict(
                 repo=sandbox.input_repo_name,
                 id=sandbox.commit.id,
@@ -70,7 +75,11 @@ def test_inspect_subjob():
     sandbox = Sandbox("inspect_subjob")
     job_id = sandbox.wait()
 
-    job_info = list(sandbox.client.inspect_job(job_id, sandbox.pipeline_repo_name))
+    job_info = list(
+        sandbox.client.inspect_job(
+            job_id, sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )
     assert job_info[0].job.id == job_id
 
 
@@ -94,13 +103,17 @@ def test_stop_job():
     pipeline_name = sandbox.pipeline_repo_name
     job_id = sandbox.wait()
 
-    sandbox.client.stop_job(job_id, pipeline_name)
+    sandbox.client.stop_job(job_id, pipeline_name, project_name=sandbox.project_name)
     # This is necessary because `StopJob` does not wait for the job to be
     # killed before returning a result.
     # TODO: remove once this is fixed:
     # https://github.com/pachyderm/pachyderm/issues/3856
     time.sleep(1)
-    job_info = list(sandbox.client.inspect_job(job_id, pipeline_name))
+    job_info = list(
+        sandbox.client.inspect_job(
+            job_id, pipeline_name, project_name=sandbox.project_name
+        )
+    )
     # We race to stop the job before it finishes - if we lose the race, it will
     # be in state JOB_SUCCESS
     assert job_info[0].state in [
@@ -113,7 +126,9 @@ def test_delete_job():
     sandbox = Sandbox("delete_job")
     job_id = sandbox.wait()
     orig_job_count = len(list(sandbox.client.list_job()))
-    sandbox.client.delete_job(job_id, sandbox.pipeline_repo_name)
+    sandbox.client.delete_job(
+        job_id, sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
     jobs = len(list(sandbox.client.list_job()))
     assert jobs == orig_job_count - 1
 
@@ -126,9 +141,15 @@ def test_datums():
     # flush the job so it fully finishes
     list(sandbox.client.wait_commit(sandbox.commit.id))
 
-    datums = list(sandbox.client.list_datum(pipeline_name, job_id))
+    datums = list(
+        sandbox.client.list_datum(
+            pipeline_name, job_id, project_name=sandbox.project_name
+        )
+    )
     assert len(datums) == 1
-    datum = sandbox.client.inspect_datum(pipeline_name, job_id, datums[0].datum.id)
+    datum = sandbox.client.inspect_datum(
+        pipeline_name, job_id, datums[0].datum.id, project_name=sandbox.project_name
+    )
     assert datum.state == pps_proto.DatumState.SUCCESS
 
     with pytest.raises(
@@ -137,7 +158,9 @@ def test_datums():
             job_id
         ),
     ):
-        sandbox.client.restart_datum(pipeline_name, job_id)
+        sandbox.client.restart_datum(
+            pipeline_name, job_id, project_name=sandbox.project_name
+        )
 
     datums = list(
         sandbox.client.list_datum(
@@ -155,10 +178,16 @@ def test_datums():
 
 def test_inspect_pipeline():
     sandbox = Sandbox("inspect_pipeline")
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert pipeline.pipeline.name == sandbox.pipeline_repo_name
     pipelines = list(
-        sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name, history=-1)
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name, history=-1
+        )
     )
     assert sandbox.pipeline_repo_name in [p.pipeline.name for p in pipelines]
 
@@ -174,7 +203,9 @@ def test_list_pipeline():
 def test_delete_pipeline():
     sandbox = Sandbox("delete_pipeline")
     orig_pipeline_count = len(list(sandbox.client.list_pipeline()))
-    sandbox.client.delete_pipeline(sandbox.pipeline_repo_name)
+    sandbox.client.delete_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
     assert len(list(sandbox.client.list_pipeline())) == orig_pipeline_count - 1
 
 
@@ -188,12 +219,24 @@ def test_delete_all_pipelines():
 def test_restart_pipeline():
     sandbox = Sandbox("restart_job")
 
-    sandbox.client.stop_pipeline(sandbox.pipeline_repo_name)
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    sandbox.client.stop_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert pipeline.stopped
 
-    sandbox.client.start_pipeline(sandbox.pipeline_repo_name)
-    pipeline = list(sandbox.client.inspect_pipeline(sandbox.pipeline_repo_name))[0]
+    sandbox.client.start_pipeline(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name
+    )
+    pipeline = list(
+        sandbox.client.inspect_pipeline(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
+    )[0]
     assert not pipeline.stopped
 
 
@@ -207,7 +250,9 @@ def test_run_cron():
     # cron input
     # NOTE: `e` is used after the context
     with pytest.raises(python_pachyderm.RpcError, match=r"pipeline.*have a cron input"):
-        sandbox.client.run_cron(sandbox.pipeline_repo_name)
+        sandbox.client.run_cron(
+            sandbox.pipeline_repo_name, project_name=sandbox.project_name
+        )
 
 
 def test_secrets():
@@ -242,12 +287,17 @@ def test_get_pipeline_logs():
     sandbox.wait()
 
     # Just make sure these spit out some logs
-    logs = sandbox.client.get_pipeline_logs(sandbox.pipeline_repo_name, follow=True)
+    logs = sandbox.client.get_pipeline_logs(
+        sandbox.pipeline_repo_name, project_name=sandbox.project_name, follow=True
+    )
     assert next(logs) is not None
     del logs
 
     logs = sandbox.client.get_pipeline_logs(
-        sandbox.pipeline_repo_name, master=True, follow=True
+        sandbox.pipeline_repo_name,
+        project_name=sandbox.project_name,
+        master=True,
+        follow=True,
     )
     assert next(logs) is not None
     del logs
@@ -263,7 +313,9 @@ def test_get_job_logs():
     sandbox.client.wait_commit(commit)
 
     # Just make sure these spit out some logs
-    logs = sandbox.client.get_job_logs(pipeline_name, job_id, follow=True)
+    logs = sandbox.client.get_job_logs(
+        pipeline_name, job_id, project_name=sandbox.project_name, follow=True
+    )
     assert next(logs) is not None
     del logs
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -77,16 +77,13 @@ def create_test_pipeline(client: python_pachyderm.Client, test_name):
 
     client.create_pipeline(
         pipeline_repo_name,
+        project_name=project_name,
         transform=pps_proto.Transform(
             cmd=["sh"],
             image="alpine",
             stdin=["cp /pfs/{}/*.dat /pfs/out/".format(input_repo_name)],
         ),
-        input=pps_proto.Input(
-            pfs=pps_proto.PFSInput(
-                glob="/*", repo=input_repo_name, project=project_name
-            )
-        ),
+        input=pps_proto.Input(pfs=pps_proto.PFSInput(glob="/*", repo=input_repo_name)),
     )
 
     with client.commit(input_repo_name, "master", project_name=project_name) as commit:


### PR DESCRIPTION
Several bugs in the PPS Mixin classes regarding specifying a pipeline in relation to a project. Additionally added some more tests for project methods within the PFS mixin. 

Also of note, had to update the `test_pps.py::test_get_pipeline_logs` tests because of an issue where the combination of the project and pipeline names were too long. 

Still looking into the one tests that is failing `experimental/test_pps.py::test_delete_pipeline`. I'm not yet sure why only the experimental test is breaking and why I can't get it to break locally.