### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.6-slim
 LABEL maintainer="jdoliner@pachyderm.io"
 
 RUN pip3 install grpcio==1.38.0 grpcio-tools==1.38.0
-RUN apt-get update && apt-get install -y gcc
+RUN apt-get update && apt-get install -y gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip3 install "betterproto[compiler]"==2.0.0b3
 
 ADD run /bin


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance