### PR TITLE
Datum Batching

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,18 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
-
-[[package]]
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
@@ -99,7 +87,6 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -107,6 +94,18 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "cachetools"
+version = "5.3.0"
+description = "Extensible memoizing collections and decorators"
+category = "dev"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
+    {file = "cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
+]
 
 [[package]]
 name = "certifi"
@@ -130,6 +129,18 @@ python-versions = ">=3.6.1"
 files = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.1.0"
+description = "Universal encoding detector for Python 3"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
+    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
 ]
 
 [[package]]
@@ -231,7 +242,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -313,7 +323,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.1.0,<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.9.0,<2.10.0"
 pyflakes = ">=2.5.0,<2.6.0"
@@ -450,26 +459,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "4.2.0"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
-    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -513,7 +502,6 @@ files = [
 
 [package.dependencies]
 attrs = ">=19,<22"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 code-style = ["pre-commit (==2.6)"]
@@ -723,9 +711,6 @@ files = [
     {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.5", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
@@ -742,33 +727,28 @@ files = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.20.0"
+version = "3.3.2"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
-    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
+    {file = "pre_commit-3.3.2-py2.py3-none-any.whl", hash = "sha256:8056bc52181efadf4aac792b1f4f255dfd2fb5a350ded7335d251a68561e8cb6"},
+    {file = "pre_commit-3.3.2.tar.gz", hash = "sha256:66e37bec2d882de1f17f88075047ef8962581f83c234ac08da21a0c58953d1f0"},
 ]
 
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
-toml = "*"
-virtualenv = ">=20.0.8"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "protobuf"
@@ -800,18 +780,6 @@ files = [
     {file = "protobuf-3.20.3-cp39-cp39-win_amd64.whl", hash = "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7"},
     {file = "protobuf-3.20.3-py2.py3-none-any.whl", hash = "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db"},
     {file = "protobuf-3.20.3.tar.gz", hash = "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"},
-]
-
-[[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 
 [[package]]
@@ -854,6 +822,26 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "pyproject-api"
+version = "1.5.1"
+description = "API to interact with the python pyproject.toml based projects"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyproject_api-1.5.1-py3-none-any.whl", hash = "sha256:4698a3777c2e0f6b624f8a4599131e2a25376d90fe8d146d7ac74c67c6f97c43"},
+    {file = "pyproject_api-1.5.1.tar.gz", hash = "sha256:435f46547a9ff22cf4208ee274fca3e2869aeb062a4834adfc99a4dd64af3cf9"},
+]
+
+[package.dependencies]
+packaging = ">=23"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+testing = ["covdefaults (>=2.2.2)", "importlib-metadata (>=6)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "virtualenv (>=20.17.1)", "wheel (>=0.38.4)"]
+
+[[package]]
 name = "pytest"
 version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
@@ -868,7 +856,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -909,6 +896,21 @@ files = [
 
 [package.dependencies]
 pytest = ">=5.0.0"
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
@@ -1012,18 +1014,6 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-
-[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -1092,14 +1082,14 @@ dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
-version = "1.0.2"
-description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+version = "1.0.4"
+description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
-    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 
 [package.extras]
@@ -1124,14 +1114,14 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
-version = "2.0.0"
+version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
-    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
+    {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
+    {file = "sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"},
 ]
 
 [package.extras]
@@ -1186,18 +1176,6 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1211,75 +1189,42 @@ files = [
 
 [[package]]
 name = "tox"
-version = "3.28.0"
+version = "4.5.1"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "tox-3.28.0-py2.py3-none-any.whl", hash = "sha256:57b5ab7e8bb3074edc3c0c0b4b192a4f3799d3723b2c5b76f1fa9f2d40316eea"},
-    {file = "tox-3.28.0.tar.gz", hash = "sha256:d0d28f3fe6d6d7195c27f8b054c3e99d5451952b54abdae673b71609a581f640"},
+    {file = "tox-4.5.1-py3-none-any.whl", hash = "sha256:d25a2e6cb261adc489604fafd76cd689efeadfa79709965e965668d6d3f63046"},
+    {file = "tox-4.5.1.tar.gz", hash = "sha256:5a2eac5fb816779dfdf5cb00fecbc27eb0524e4626626bb1de84747b24cacc56"},
 ]
 
 [package.dependencies]
-colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
-filelock = ">=3.0.0"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-packaging = ">=14"
-pluggy = ">=0.12.0"
-py = ">=1.4.17"
-six = ">=1.14.0"
-tomli = {version = ">=2.0.1", markers = "python_version >= \"3.7\" and python_version < \"3.11\""}
-virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+cachetools = ">=5.3"
+chardet = ">=5.1"
+colorama = ">=0.4.6"
+filelock = ">=3.11"
+packaging = ">=23.1"
+platformdirs = ">=3.2"
+pluggy = ">=1"
+pyproject-api = ">=1.5.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.21"
 
 [package.extras]
-docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
-
-[[package]]
-name = "typed-ast"
-version = "1.5.4"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
+docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-argparse-cli (>=1.11)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2022.1.2b11)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+testing = ["build[virtualenv] (>=0.10)", "covdefaults (>=2.3)", "devpi-process (>=0.3)", "diff-cover (>=7.5)", "distlib (>=0.3.6)", "flaky (>=3.7)", "hatch-vcs (>=0.3)", "hatchling (>=1.14)", "psutil (>=5.9.4)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-xdist (>=3.2.1)", "re-assert (>=1.1)", "time-machine (>=2.9)", "wheel (>=0.40)"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.1"
+version = "4.6.2"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.6.1-py3-none-any.whl", hash = "sha256:6bac751f4789b135c43228e72de18637e9a6c29d12777023a703fd1a6858469f"},
-    {file = "typing_extensions-4.6.1.tar.gz", hash = "sha256:558bc0c4145f01e6405f4a5fdbd82050bd221b119f4bf72a961a1cfd471349d6"},
+    {file = "typing_extensions-4.6.2-py3-none-any.whl", hash = "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"},
+    {file = "typing_extensions-4.6.2.tar.gz", hash = "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c"},
 ]
 
 [[package]]
@@ -1302,44 +1247,26 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.4.7"
+version = "20.23.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.4.7-py2.py3-none-any.whl", hash = "sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76"},
-    {file = "virtualenv-20.4.7.tar.gz", hash = "sha256:14fdf849f80dbb29a4eb6caa9875d476ee2a5cf76a5f5415fa2f1606010ab467"},
+    {file = "virtualenv-20.23.0-py3-none-any.whl", hash = "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e"},
+    {file = "virtualenv-20.23.0.tar.gz", hash = "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"},
 ]
 
 [package.dependencies]
-appdirs = ">=1.4.3,<2"
-distlib = ">=0.3.1,<1"
-filelock = ">=3.0.0,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-six = ">=1.9.0,<2"
+distlib = ">=0.3.6,<1"
+filelock = ">=3.11,<4"
+platformdirs = ">=3.2,<4"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "xonsh (>=0.9.16)"]
-
-[[package]]
-name = "zipp"
-version = "3.15.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.7.1)", "time-machine (>=2.9)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<4.0"
-content-hash = "d7d820a10bd840b5438b4c58c2a252b21af4a96aaa9ea350ed50fd1bf30696e6"
+python-versions = ">=3.8,<4.0"
+content-hash = "f6a7fa77f45dc0a769e7ac55b7d754ae78c833d31da5fd2db989980ece90f0c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,13 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 grpcio = ">=1.54.2"
 grpcio-health-checking = ">=1.38.0"
 grpc-interceptor = "^0.13.0"
 importlib-metadata = { version = ">1.5.1", python = "<3.8" }
 protobuf = ">=3.17.1,<4.0.0"
+python-dotenv = ">=1.0.0"
 
 [tool.poetry.dev-dependencies]
 black = ">=22.6.0"

--- a/src/python_pachyderm/__init__.py
+++ b/src/python_pachyderm/__init__.py
@@ -7,6 +7,7 @@ from google.protobuf.internal.enum_type_wrapper import (
 
 from .mixin.pfs import PFSFile, ModifyFileClient
 from .client import Client, ConfigError, BadClusterDeploymentID
+from .datum_batching import batch_all_datums
 from .util import (
     put_files,
     parse_json_pipeline_spec,
@@ -35,6 +36,7 @@ __all__ = [
     "parse_dict_pipeline_spec",
     "ConfigError",
     "BadClusterDeploymentID",
+    "batch_all_datums",
 ]
 
 __version__ = ""

--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -496,7 +496,7 @@ class Client(
             channel = _create_channel(
                 address=f"localhost:{port}",
                 root_certs=None,
-                options=GRPC_CHANNEL_OPTIONS
+                options=GRPC_CHANNEL_OPTIONS,
             )
             self._worker = _WorkerStub(channel)
         return self._worker

--- a/src/python_pachyderm/client.py
+++ b/src/python_pachyderm/client.py
@@ -21,6 +21,7 @@ from .mixin.pfs import PFSMixin
 from .mixin.pps import PPSMixin
 from .mixin.transaction import TransactionMixin
 from .mixin.version import VersionMixin
+from .mixin.worker import WorkerMixin as _WorkerStub
 from .service import Service, GRPC_CHANNEL_OPTIONS
 
 
@@ -174,6 +175,7 @@ class Client(
             self._metadata = self._build_metadata()
             self._channel = _apply_metadata_interceptor(channel, self._metadata)
         super().__init__()  # Initialize all the Mixin classes.
+        self._worker: Optional[_WorkerStub] = None
 
     @classmethod
     def new_in_cluster(
@@ -473,6 +475,31 @@ class Client(
             metadata=self._metadata,
         )
         super().__init__()
+
+    @property
+    def worker(self) -> _WorkerStub:
+        """Access the worker API stub.
+
+        This is dynamically loaded in order to provide a helpful error message
+        to the user if they try to interact with the worker API from outside
+        a worker.
+        """
+        worker_port_env = "PPS_WORKER_GRPC_PORT"
+        if self._worker is None:
+            port = os.environ.get(worker_port_env)
+            if port is None:
+                raise ConnectionError(
+                    f"Cannot connect to the worker since {worker_port_env} is not set. "
+                    "Are you running inside a pipeline?"
+                )
+            # Note: This channel doe not go through the metadata interceptor.
+            channel = _create_channel(
+                address=f"localhost:{port}",
+                root_certs=None,
+                options=GRPC_CHANNEL_OPTIONS
+            )
+            self._worker = _WorkerStub(channel)
+        return self._worker
 
     def _build_metadata(self):
         metadata = []

--- a/src/python_pachyderm/datum_batching.py
+++ b/src/python_pachyderm/datum_batching.py
@@ -12,7 +12,7 @@ def batch_all_datums(user_code: PIPELINE_FUNC) -> PIPELINE_FUNC:
     this decorator will call the NextDatum endpoint within the worker
     and set any environment variables specified by the worker.
 
-    Any expeections raised during the execution of the wrapped function
+    Any expections raised during the execution of the wrapped function
     will be reported back to the worker. See the pachyderm documentation
     for more information on how the datum batching feature works.
 
@@ -26,6 +26,12 @@ def batch_all_datums(user_code: PIPELINE_FUNC) -> PIPELINE_FUNC:
     >>> def pipeline():
     >>>     # process datums
     >>>     pass
+    >>>
+    >>> if __name__ == '__main__':
+    >>>   # Perform an expensive computation here before
+    >>>   #   entering your datum processing function
+    >>>   #   i.e. initializing a model.
+    >>>   pipeline()
     """
 
     @wraps(user_code)

--- a/src/python_pachyderm/datum_batching.py
+++ b/src/python_pachyderm/datum_batching.py
@@ -1,0 +1,38 @@
+from functools import wraps
+from typing import Callable
+
+from . import Client
+
+PIPELINE_FUNC = Callable[..., None]
+
+
+def batch_all_datums(user_code: PIPELINE_FUNC) -> PIPELINE_FUNC:
+    """A decorator that will repeatedly call the wrapped function until
+    all datums have been processed. Before calling the wrapped function,
+    this decorator will call the NextDatum endpoint within the worker
+    and set any environment variables specified by the worker.
+
+    Any expeections raised during the execution of the wrapped function
+    will be reported back to the worker. See the pachyderm documentation
+    for more information on how the datum batching feature works.
+
+    Note: This can only be used within a Pachyderm worker.
+
+    Examples
+    --------
+    >>> from python_pachyderm import batch_all_datums
+    >>>
+    >>> @batch_all_datums
+    >>> def pipeline():
+    >>>     # process datums
+    >>>     pass
+    """
+
+    @wraps(user_code)
+    def wrapper(*args, **kwargs) -> None:
+        worker = Client().worker
+        while True:
+            with worker.batch_datum():
+                user_code(*args, **kwargs)
+
+    return wrapper

--- a/src/python_pachyderm/mixin/worker.py
+++ b/src/python_pachyderm/mixin/worker.py
@@ -9,6 +9,7 @@ from python_pachyderm.proto.v2.worker import worker_pb2, worker_pb2_grpc
 
 class WorkerMixin:
     """A mixin for worker binary-related functionality."""
+
     _dotenv_path = "/pfs/.env"
     __error: Optional[str] = None  # used by batch_datum
 

--- a/src/python_pachyderm/mixin/worker.py
+++ b/src/python_pachyderm/mixin/worker.py
@@ -56,6 +56,11 @@ class WorkerMixin:
         >>> from python_pachyderm import Client
         >>>
         >>> worker = Client().worker
+        >>>
+        >>> # Perform an expensive computation here before
+        >>> #   you being processing your datums
+        >>> #   i.e. initializing a model.
+        >>>
         >>> while True:
         >>>     with worker.batch_datum():
         >>>         # process datums

--- a/src/python_pachyderm/mixin/worker.py
+++ b/src/python_pachyderm/mixin/worker.py
@@ -1,0 +1,71 @@
+from contextlib import contextmanager
+from typing import ContextManager, Optional
+
+import grpc
+from dotenv import load_dotenv
+
+from python_pachyderm.proto.v2.worker import worker_pb2, worker_pb2_grpc
+
+
+class WorkerMixin:
+    """A mixin for worker binary-related functionality."""
+    _dotenv_path = "/pfs/.env"
+    __error: Optional[str] = None  # used by batch_datum
+
+    def __init__(self, channel: grpc.Channel):
+        """
+        Note: This API stub must have an open grpc channel work the worker binary.
+        The ``Client`` object should automatically do this for the user.
+        """
+        self.__stub = worker_pb2_grpc.WorkerStub(channel)
+        super().__init__()
+
+    def next_datum(self, *, error: str = "") -> worker_pb2.NextDatumResponse:
+        """Calls the NextDatum endpoint within the worker to step forward during
+        datum batching.
+
+        Parameters
+        ----------
+        error : str, optional
+            An error message to report to the worker binary indicating the current
+            datum could not be processed.
+        """
+        message = worker_pb2.NextDatumRequest(error=error)
+        return self.__stub.NextDatum(message)
+
+    @contextmanager
+    def batch_datum(self) -> ContextManager:
+        """A ContextManager that, when entered, calls the NextDatum
+        endpoint within the worker to step forward during datum batching.
+        This context manager will also prepare the environment for the user
+        and report errors that occur back to the worker.
+
+        This context manager expects to be called within an infinite while
+        loop -- see the examples section. This context can only be entered
+        from within a Pachyderm worker and the worker will terminate your
+        code when all datums have been processed.
+
+        Note: The API stub must have an open gRPC channel with the worker
+        for NextDatum to function correctly. The ``Client`` object
+        should automatically do this for the user.
+
+        Examples
+        --------
+        >>> from python_pachyderm import Client
+        >>>
+        >>> worker = Client().worker
+        >>> while True:
+        >>>     with worker.batch_datum():
+        >>>         # process datums
+        >>>         pass
+        """
+        self.next_datum(error=self.__error or "")
+        load_dotenv(self._dotenv_path, override=True)
+
+        self.__error = None
+        try:
+            yield
+        except Exception as error:
+            self.__error = repr(error)
+            # TODO: Probably want better logging here than a print statement.
+            print(f"{self.__error}\nReporting above error to worker.")

--- a/src/python_pachyderm/mixin/worker.py
+++ b/src/python_pachyderm/mixin/worker.py
@@ -15,8 +15,9 @@ class WorkerMixin:
 
     def __init__(self, channel: grpc.Channel):
         """
-        Note: This API stub must have an open grpc channel work the worker binary.
-        The ``Client`` object should automatically do this for the user.
+        Note: This API stub must have an open grpc channel work the worker
+        binary. The ``Client`` object should automatically do this for
+        the user.
         """
         self.__stub = worker_pb2_grpc.WorkerStub(channel)
         super().__init__()
@@ -28,8 +29,8 @@ class WorkerMixin:
         Parameters
         ----------
         error : str, optional
-            An error message to report to the worker binary indicating the current
-            datum could not be processed.
+            An error message to report to the worker binary indicating the
+            current datum could not be processed.
         """
         message = worker_pb2.NextDatumRequest(error=error)
         return self.__stub.NextDatum(message)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,140 @@
+from typing import Callable
+
+from python_pachyderm import Client
+from python_pachyderm.proto.v2.pps import pps_pb2
+
+from .test_pfs import _client_fixture, _repo_fixture
+
+IMAGE_NAME = "bonenfan5ben/datum_batching:0037pp"  # TODO: Don't do this.
+
+
+def generate_stdin(func: Callable[[], None]):
+    """Generates the stdin field of for the test pipelines.
+
+    Args:
+        func: The function containing the "user code" of the test pipeline.
+          This must be defined at the root of the script, i.e. not as a
+          method to a class or defined within another function.
+    """
+    from inspect import getsource
+    from textwrap import dedent
+
+    test_script = (
+        f'{dedent(getsource(func))}\n\n'
+        'if __name__ == "__main__":\n'
+        f'    {func.__name__}()\n'
+    )
+    return [
+        f"echo '{test_script}' > main.py",
+        "python3 main.py",
+    ]
+
+
+def test_datum_batching(client: Client, repo: str):
+    """Test that exceptions within the user code is caught, reported to the
+    worker binary, and iteration continues.
+
+    This test uploads 10 files to the input repo and the user code
+      copies each file to the output repo. The pipeline job should finish
+      successfully and the output repo should contain 10 files.
+    """
+
+    def user_code():
+        """Assert the one file is mounted in /pfs/batch_datums_input
+        and copy it to /pfs/out.
+        """
+        import os
+        import shutil
+        from python_pachyderm import batch_all_datums
+
+        @batch_all_datums
+        def main():
+            datum_files = os.listdir("/pfs/batch_datums_input")
+            print(datum_files)
+            assert len(datum_files) == 1
+            shutil.copy(f"/pfs/batch_datums_input/{datum_files[0]}", f"/pfs/out/{datum_files[0]}")
+        return main()
+
+    input_files = [f"/file_{i:02d}.dat" for i in range(10)]
+    with client.commit(repo, "master") as commit:
+        for file in input_files:
+            client.put_file_bytes(commit, file, b"DATA")
+
+    pipeline_name = "datum_batching_pipeline"
+    try:
+        client.create_pipeline(
+            pipeline_name=pipeline_name,
+            input=pps_pb2.Input(
+                pfs=pps_pb2.PFSInput(
+                    repo=repo,
+                    name="batch_datums_input",  # Name explicitly set for user code.
+                    glob="/*",
+                )
+            ),
+            transform=pps_pb2.Transform(
+                cmd=["bash", ],
+                datum_batching=True,
+                image=IMAGE_NAME,
+                stdin=generate_stdin(user_code)
+            )
+        )
+        job_info = next(client.list_job(pipeline_name))
+        next(client.inspect_job(job_info.job.id, pipeline_name, wait=True))
+
+        output_files = client.list_file(job_info.output_commit, path="/")
+        assert len(list(output_files)) == len(input_files)
+    finally:  # Cleanup our manually defined test pipeline.
+        client.delete_pipeline(pipeline_name, force=True)
+
+
+def test_datum_batching_errors(client: Client, repo: str):
+    """Test that exceptions within the user code is caught, reported to the
+    worker binary, and iteration continues.
+
+    This test uploads a single file to the input repo and the user code
+      always raises an exception. The pipeline has err_cmd set to "true", so
+      the pipeline job should finish successfully and the output repo should
+      be empty.
+    """
+    def user_code_errors():
+        """Raises an Exception for every datum."""
+        from python_pachyderm import Client
+
+        worker = Client().worker
+        while True:
+            with worker.batch_datum():
+                raise Exception("Something Bad Happened!")
+
+    with client.commit(repo, "master") as commit:
+        client.put_file_bytes(commit, path="/file.dat", value=b"DATA")
+
+    pipeline_name = "datum_batching_pipeline_error"
+    try:
+        client.create_pipeline(
+            pipeline_name=pipeline_name,
+            input=pps_pb2.Input(
+                pfs=pps_pb2.PFSInput(
+                    repo=repo,
+                    name="batch_datums_input",  # Name explicitly set for user code.
+                    glob="/*",
+                )
+            ),
+            transform=pps_pb2.Transform(
+                cmd=["bash", ],
+                err_cmd=["true", ],  # Note err_cmd set.
+                datum_batching=True,
+                image=IMAGE_NAME,
+                stdin=generate_stdin(user_code_errors)
+            )
+        )
+        started_job = next(client.list_job(pipeline_name))
+        completed_job = next(
+            client.inspect_job(started_job.job.id, pipeline_name, wait=True)
+        )
+        assert completed_job.state == pps_pb2.JobState.JOB_SUCCESS
+
+        output_files = client.list_file(started_job.output_commit, path="/")
+        assert len(list(output_files)) == 0
+    finally:  # Cleanup our manually defined test pipeline.
+        # pass
+        client.delete_pipeline(pipeline_name, force=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -20,9 +20,9 @@ def generate_stdin(func: Callable[[], None]):
     from textwrap import dedent
 
     test_script = (
-        f'{dedent(getsource(func))}\n\n'
+        f"{dedent(getsource(func))}\n\n"
         'if __name__ == "__main__":\n'
-        f'    {func.__name__}()\n'
+        f"    {func.__name__}()\n"
     )
     return [
         f"echo '{test_script}' > main.py",
@@ -52,7 +52,11 @@ def test_datum_batching(client: Client, repo: str):
             datum_files = os.listdir("/pfs/batch_datums_input")
             print(datum_files)
             assert len(datum_files) == 1
-            shutil.copy(f"/pfs/batch_datums_input/{datum_files[0]}", f"/pfs/out/{datum_files[0]}")
+            shutil.copy(
+                f"/pfs/batch_datums_input/{datum_files[0]}",
+                f"/pfs/out/{datum_files[0]}",
+            )
+
         return main()
 
     input_files = [f"/file_{i:02d}.dat" for i in range(10)]
@@ -72,11 +76,13 @@ def test_datum_batching(client: Client, repo: str):
                 )
             ),
             transform=pps_pb2.Transform(
-                cmd=["bash", ],
+                cmd=[
+                    "bash",
+                ],
                 datum_batching=True,
                 image=IMAGE_NAME,
-                stdin=generate_stdin(user_code)
-            )
+                stdin=generate_stdin(user_code),
+            ),
         )
         job_info = next(client.list_job(pipeline_name))
         next(client.inspect_job(job_info.job.id, pipeline_name, wait=True))
@@ -96,6 +102,7 @@ def test_datum_batching_errors(client: Client, repo: str):
       the pipeline job should finish successfully and the output repo should
       be empty.
     """
+
     def user_code_errors():
         """Raises an Exception for every datum."""
         from python_pachyderm import Client
@@ -120,12 +127,16 @@ def test_datum_batching_errors(client: Client, repo: str):
                 )
             ),
             transform=pps_pb2.Transform(
-                cmd=["bash", ],
-                err_cmd=["true", ],  # Note err_cmd set.
+                cmd=[
+                    "bash",
+                ],
+                err_cmd=[
+                    "true",
+                ],  # Note err_cmd set.
                 datum_batching=True,
                 image=IMAGE_NAME,
-                stdin=generate_stdin(user_code_errors)
-            )
+                stdin=generate_stdin(user_code_errors),
+            ),
         )
         started_job = next(client.list_job(pipeline_name))
         completed_job = next(


### PR DESCRIPTION
Implementation of datum batching within python-pachyderm. This is not duplicated within the experimental client.

Things of note:
  * Had to drop python3.7 support for the python_dotenv package. Official support ends for 3.7 in a couple months anyways.
  * `WorkerMixin` isn't really a mixin. Accessing the API is done through the `Client.worker` property (excluding the decorator which is top-level importable). This was done to match the accessing pattern done within the pachyderm_sdk (new python sdk). 

Remaining work:
  - [ ] Build image for testing datum batching in CI instead of using a static image.