### PR TITLE
Proto regen for 2.7.0

### DIFF
--- a/etc/proto_lint/proto_lint.py
+++ b/etc/proto_lint/proto_lint.py
@@ -366,7 +366,7 @@ RENAMED_ARGS = {
         ("pod_spec", None),
         ("tf_job", None),
         ("output_branch", "output_branch_name"),
-        ("details_json", None)
+        ("details_json", None),
     ],
     "create_tf_job_pipeline": [
         ("pipeline", "pipeline_name"),

--- a/etc/proto_lint/proto_lint.py
+++ b/etc/proto_lint/proto_lint.py
@@ -147,6 +147,8 @@ RENAMED_METHODS = {
     },
     Service.DEBUG: {
         "profile": ["profile_cpu"],
+        "dump_v2": ["dump"],
+        "get_dump_v2_template": ["get_dump_template"],
     },
     Service.ENTERPRISE: {
         "activate": ["activate_enterprise"],
@@ -210,6 +212,7 @@ RENAMED_ARGS = {
     # admin
     "inspect_cluster": [
         ("client_version", None),
+        ("current_project", None),
     ],
     # auth
     "authenticate_oidc": [
@@ -221,6 +224,14 @@ RENAMED_ARGS = {
     "profile_cpu": [
         ("profile", None),
         (None, "duration"),
+    ],
+    "dump": [
+        ("limit", None),
+        ("filter", None),
+        (None, "system"),
+        (None, "pipelines"),
+        (None, "input_repos"),
+        (None, "timeout"),
     ],
     # PFS
     "create_repo": [("repo", "repo_name"), ("project", "project_name")],
@@ -355,6 +366,7 @@ RENAMED_ARGS = {
         ("pod_spec", None),
         ("tf_job", None),
         ("output_branch", "output_branch_name"),
+        ("details_json", None)
     ],
     "create_tf_job_pipeline": [
         ("pipeline", "pipeline_name"),

--- a/src/python_pachyderm/mixin/debug.py
+++ b/src/python_pachyderm/mixin/debug.py
@@ -77,15 +77,10 @@ class DebugMixin:
         filters : List[str], optional
             No supported filters - this argument has no effect.
 
-        Yields
+        Returns
         -------
         debug_pb2.DumpV2Request
-            The request to
-
-        Examples
-        --------
-        >>> for b in client.dump():
-        >>>     print(b)
+            The request that can be sent to the DumpV2 API.
 
         .. # noqa: W505
         """

--- a/src/python_pachyderm/mixin/pps.py
+++ b/src/python_pachyderm/mixin/pps.py
@@ -416,6 +416,8 @@ class PPSMixin:
         autoscaling: bool = False,
         tolerations: List[pps_pb2.Toleration] = None,
         sidecar_resource_requests: pps_pb2.ResourceSpec = None,
+        dry_run: bool = False,
+        determined: pps_pb2.Determined = None,
     ) -> None:
         """Creates a pipeline.
 
@@ -547,6 +549,9 @@ class PPSMixin:
             reprocess_spec=reprocess_spec,
             autoscaling=autoscaling,
             tolerations=tolerations,
+            sidecar_resource_requests=sidecar_resource_requests,
+            dry_run=dry_run,
+            determined=determined,
         )
         self.__stub.CreatePipeline(message)
 

--- a/src/python_pachyderm/proto/v2/admin/admin_pb2.py
+++ b/src/python_pachyderm/proto/v2/admin/admin_pb2.py
@@ -12,6 +12,7 @@ _sym_db = _symbol_database.Default()
 
 
 from python_pachyderm.proto.v2.version.versionpb import version_pb2 as python__pachyderm_dot_proto_dot_v2_dot_version_dot_versionpb_dot_version__pb2
+from python_pachyderm.proto.v2.pfs import pfs_pb2 as python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -20,9 +21,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z+github.com/pachyderm/pachyderm/v2/src/admin',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n+python_pachyderm/proto/v2/admin/admin.proto\x12\x08\x61\x64min_v2\x1a\x39python_pachyderm/proto/v2/version/versionpb/version.proto\"g\n\x0b\x43lusterInfo\x12\n\n\x02id\x18\x01 \x01(\t\x12\x15\n\rdeployment_id\x18\x02 \x01(\t\x12\x1b\n\x13version_warnings_ok\x18\x03 \x01(\x08\x12\x18\n\x10version_warnings\x18\x04 \x03(\t\"F\n\x15InspectClusterRequest\x12-\n\x0e\x63lient_version\x18\x01 \x01(\x0b\x32\x15.versionpb_v2.Version2Q\n\x03\x41PI\x12J\n\x0eInspectCluster\x12\x1f.admin_v2.InspectClusterRequest\x1a\x15.admin_v2.ClusterInfo\"\x00\x42-Z+github.com/pachyderm/pachyderm/v2/src/adminb\x06proto3'
+  serialized_pb=b'\n+python_pachyderm/proto/v2/admin/admin.proto\x12\x08\x61\x64min_v2\x1a\x39python_pachyderm/proto/v2/version/versionpb/version.proto\x1a\'python_pachyderm/proto/v2/pfs/pfs.proto\"\x8e\x01\n\x0b\x43lusterInfo\x12\n\n\x02id\x18\x01 \x01(\t\x12\x15\n\rdeployment_id\x18\x02 \x01(\t\x12\x1b\n\x13version_warnings_ok\x18\x03 \x01(\x08\x12\x18\n\x10version_warnings\x18\x04 \x03(\t\x12\x12\n\nproxy_host\x18\x05 \x01(\t\x12\x11\n\tproxy_tls\x18\x06 \x01(\x08\"p\n\x15InspectClusterRequest\x12-\n\x0e\x63lient_version\x18\x01 \x01(\x0b\x32\x15.versionpb_v2.Version\x12(\n\x0f\x63urrent_project\x18\x02 \x01(\x0b\x32\x0f.pfs_v2.Project2Q\n\x03\x41PI\x12J\n\x0eInspectCluster\x12\x1f.admin_v2.InspectClusterRequest\x1a\x15.admin_v2.ClusterInfo\"\x00\x42-Z+github.com/pachyderm/pachyderm/v2/src/adminb\x06proto3'
   ,
-  dependencies=[python__pachyderm_dot_proto_dot_v2_dot_version_dot_versionpb_dot_version__pb2.DESCRIPTOR,])
+  dependencies=[python__pachyderm_dot_proto_dot_v2_dot_version_dot_versionpb_dot_version__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2.DESCRIPTOR,])
 
 
 
@@ -63,6 +64,20 @@ _CLUSTERINFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='proxy_host', full_name='admin_v2.ClusterInfo.proxy_host', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='proxy_tls', full_name='admin_v2.ClusterInfo.proxy_tls', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -75,8 +90,8 @@ _CLUSTERINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=116,
-  serialized_end=219,
+  serialized_start=158,
+  serialized_end=300,
 )
 
 
@@ -95,6 +110,13 @@ _INSPECTCLUSTERREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='current_project', full_name='admin_v2.InspectClusterRequest.current_project', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -107,11 +129,12 @@ _INSPECTCLUSTERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=221,
-  serialized_end=291,
+  serialized_start=302,
+  serialized_end=414,
 )
 
 _INSPECTCLUSTERREQUEST.fields_by_name['client_version'].message_type = python__pachyderm_dot_proto_dot_v2_dot_version_dot_versionpb_dot_version__pb2._VERSION
+_INSPECTCLUSTERREQUEST.fields_by_name['current_project'].message_type = python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2._PROJECT
 DESCRIPTOR.message_types_by_name['ClusterInfo'] = _CLUSTERINFO
 DESCRIPTOR.message_types_by_name['InspectClusterRequest'] = _INSPECTCLUSTERREQUEST
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -140,8 +163,8 @@ _API = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=293,
-  serialized_end=374,
+  serialized_start=416,
+  serialized_end=497,
   methods=[
   _descriptor.MethodDescriptor(
     name='InspectCluster',

--- a/src/python_pachyderm/proto/v2/auth/auth_pb2.py
+++ b/src/python_pachyderm/proto/v2/auth/auth_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z*github.com/pachyderm/pachyderm/v2/src/auth',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n)python_pachyderm/proto/v2/auth/auth.proto\x12\x07\x61uth_v2\x1a\x1fgoogle/protobuf/timestamp.proto\"%\n\x0f\x41\x63tivateRequest\x12\x12\n\nroot_token\x18\x01 \x01(\t\"&\n\x10\x41\x63tivateResponse\x12\x12\n\npach_token\x18\x01 \x01(\t\"\x13\n\x11\x44\x65\x61\x63tivateRequest\"\x14\n\x12\x44\x65\x61\x63tivateResponse\",\n\x16RotateRootTokenRequest\x12\x12\n\nroot_token\x18\x01 \x01(\t\"-\n\x17RotateRootTokenResponse\x12\x12\n\nroot_token\x18\x01 \x01(\t\"\xcb\x01\n\nOIDCConfig\x12\x0e\n\x06issuer\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\x12\x15\n\rclient_secret\x18\x03 \x01(\t\x12\x14\n\x0credirect_uri\x18\x04 \x01(\t\x12\x0e\n\x06scopes\x18\x05 \x03(\t\x12\x1e\n\x16require_email_verified\x18\x06 \x01(\x08\x12\x18\n\x10localhost_issuer\x18\x07 \x01(\x08\x12#\n\x1buser_accessible_issuer_host\x18\x08 \x01(\t\"\x19\n\x17GetConfigurationRequest\"F\n\x18GetConfigurationResponse\x12*\n\rconfiguration\x18\x01 \x01(\x0b\x32\x13.auth_v2.OIDCConfig\"E\n\x17SetConfigurationRequest\x12*\n\rconfiguration\x18\x01 \x01(\x0b\x32\x13.auth_v2.OIDCConfig\"\x1a\n\x18SetConfigurationResponse\"b\n\tTokenInfo\x12\x0f\n\x07subject\x18\x01 \x01(\t\x12.\n\nexpiration\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x14\n\x0chashed_token\x18\x03 \x01(\t\";\n\x13\x41uthenticateRequest\x12\x12\n\noidc_state\x18\x01 \x01(\t\x12\x10\n\x08id_token\x18\x02 \x01(\t\"*\n\x14\x41uthenticateResponse\x12\x12\n\npach_token\x18\x01 \x01(\t\"\x0f\n\rWhoAmIRequest\"R\n\x0eWhoAmIResponse\x12\x10\n\x08username\x18\x01 \x01(\t\x12.\n\nexpiration\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"G\n\x1cGetRolesForPermissionRequest\x12\'\n\npermission\x18\x01 \x01(\x0e\x32\x13.auth_v2.Permission\"=\n\x1dGetRolesForPermissionResponse\x12\x1c\n\x05roles\x18\x01 \x03(\x0b\x32\r.auth_v2.Role\"_\n\x05Roles\x12(\n\x05roles\x18\x01 \x03(\x0b\x32\x19.auth_v2.Roles.RolesEntry\x1a,\n\nRolesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"\x81\x01\n\x0bRoleBinding\x12\x32\n\x07\x65ntries\x18\x01 \x03(\x0b\x32!.auth_v2.RoleBinding.EntriesEntry\x1a>\n\x0c\x45ntriesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1d\n\x05value\x18\x02 \x01(\x0b\x32\x0e.auth_v2.Roles:\x02\x38\x01\"=\n\x08Resource\x12#\n\x04type\x18\x01 \x01(\x0e\x32\x15.auth_v2.ResourceType\x12\x0c\n\x04name\x18\x02 \x01(\t\"k\n\x05Users\x12\x30\n\tusernames\x18\x01 \x03(\x0b\x32\x1d.auth_v2.Users.UsernamesEntry\x1a\x30\n\x0eUsernamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"d\n\x06Groups\x12+\n\x06groups\x18\x01 \x03(\x0b\x32\x1b.auth_v2.Groups.GroupsEntry\x1a-\n\x0bGroupsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"m\n\x04Role\x12\x0c\n\x04name\x18\x01 \x01(\t\x12(\n\x0bpermissions\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\x12-\n\x0eresource_types\x18\x03 \x03(\x0e\x32\x15.auth_v2.ResourceType\"a\n\x10\x41uthorizeRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12(\n\x0bpermissions\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\"\x88\x01\n\x11\x41uthorizeResponse\x12\x12\n\nauthorized\x18\x01 \x01(\x08\x12&\n\tsatisfied\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\x12$\n\x07missing\x18\x03 \x03(\x0e\x32\x13.auth_v2.Permission\x12\x11\n\tprincipal\x18\x04 \x01(\t\"<\n\x15GetPermissionsRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\"[\n!GetPermissionsForPrincipalRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12\x11\n\tprincipal\x18\x02 \x01(\t\"Q\n\x16GetPermissionsResponse\x12(\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x13.auth_v2.Permission\x12\r\n\x05roles\x18\x02 \x03(\t\"a\n\x18ModifyRoleBindingRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12\x11\n\tprincipal\x18\x02 \x01(\t\x12\r\n\x05roles\x18\x03 \x03(\t\"\x1b\n\x19ModifyRoleBindingResponse\"<\n\x15GetRoleBindingRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\"?\n\x16GetRoleBindingResponse\x12%\n\x07\x62inding\x18\x01 \x01(\x0b\x32\x14.auth_v2.RoleBinding\"C\n\x0bSessionInfo\x12\r\n\x05nonce\x18\x01 \x01(\t\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x16\n\x0e\x63onversion_err\x18\x03 \x01(\x08\"\x15\n\x13GetOIDCLoginRequest\"8\n\x14GetOIDCLoginResponse\x12\x11\n\tlogin_url\x18\x01 \x01(\t\x12\r\n\x05state\x18\x02 \x01(\t\"2\n\x14GetRobotTokenRequest\x12\r\n\x05robot\x18\x01 \x01(\t\x12\x0b\n\x03ttl\x18\x02 \x01(\x03\"&\n\x15GetRobotTokenResponse\x12\r\n\x05token\x18\x01 \x01(\t\"\'\n\x16RevokeAuthTokenRequest\x12\r\n\x05token\x18\x01 \x01(\t\")\n\x17RevokeAuthTokenResponse\x12\x0e\n\x06number\x18\x01 \x01(\x03\";\n\x17SetGroupsForUserRequest\x12\x10\n\x08username\x18\x01 \x01(\t\x12\x0e\n\x06groups\x18\x02 \x03(\t\"\x1a\n\x18SetGroupsForUserResponse\"B\n\x14ModifyMembersRequest\x12\r\n\x05group\x18\x01 \x01(\t\x12\x0b\n\x03\x61\x64\x64\x18\x02 \x03(\t\x12\x0e\n\x06remove\x18\x03 \x03(\t\"\x17\n\x15ModifyMembersResponse\"\x12\n\x10GetGroupsRequest\"1\n\x1cGetGroupsForPrincipalRequest\x12\x11\n\tprincipal\x18\x01 \x01(\t\"#\n\x11GetGroupsResponse\x12\x0e\n\x06groups\x18\x01 \x03(\t\" \n\x0fGetUsersRequest\x12\r\n\x05group\x18\x01 \x01(\t\"%\n\x10GetUsersResponse\x12\x11\n\tusernames\x18\x01 \x03(\t\"\x1a\n\x18\x45xtractAuthTokensRequest\"?\n\x19\x45xtractAuthTokensResponse\x12\"\n\x06tokens\x18\x01 \x03(\x0b\x32\x12.auth_v2.TokenInfo\"<\n\x17RestoreAuthTokenRequest\x12!\n\x05token\x18\x01 \x01(\x0b\x32\x12.auth_v2.TokenInfo\"\x1a\n\x18RestoreAuthTokenResponse\"2\n\x1eRevokeAuthTokensForUserRequest\x12\x10\n\x08username\x18\x01 \x01(\t\"1\n\x1fRevokeAuthTokensForUserResponse\x12\x0e\n\x06number\x18\x01 \x01(\x03\" \n\x1e\x44\x65leteExpiredAuthTokensRequest\"!\n\x1f\x44\x65leteExpiredAuthTokensResponse*\xa9\x10\n\nPermission\x12\x16\n\x12PERMISSION_UNKNOWN\x10\x00\x12\x1b\n\x17\x43LUSTER_MODIFY_BINDINGS\x10\x64\x12\x18\n\x14\x43LUSTER_GET_BINDINGS\x10\x65\x12\x1b\n\x16\x43LUSTER_GET_PACHD_LOGS\x10\x94\x01\x12\x1a\n\x15\x43LUSTER_GET_LOKI_LOGS\x10\x96\x01\x12\x19\n\x15\x43LUSTER_AUTH_ACTIVATE\x10\x66\x12\x1b\n\x17\x43LUSTER_AUTH_DEACTIVATE\x10g\x12\x1b\n\x17\x43LUSTER_AUTH_GET_CONFIG\x10h\x12\x1b\n\x17\x43LUSTER_AUTH_SET_CONFIG\x10i\x12!\n\x1c\x43LUSTER_AUTH_GET_ROBOT_TOKEN\x10\x8b\x01\x12%\n!CLUSTER_AUTH_MODIFY_GROUP_MEMBERS\x10m\x12\x1b\n\x17\x43LUSTER_AUTH_GET_GROUPS\x10n\x12 \n\x1c\x43LUSTER_AUTH_GET_GROUP_USERS\x10o\x12\x1f\n\x1b\x43LUSTER_AUTH_EXTRACT_TOKENS\x10p\x12\x1e\n\x1a\x43LUSTER_AUTH_RESTORE_TOKEN\x10q\x12/\n*CLUSTER_AUTH_GET_PERMISSIONS_FOR_PRINCIPAL\x10\x8d\x01\x12\'\n\"CLUSTER_AUTH_DELETE_EXPIRED_TOKENS\x10\x8c\x01\x12$\n\x1f\x43LUSTER_AUTH_REVOKE_USER_TOKENS\x10\x8e\x01\x12#\n\x1e\x43LUSTER_AUTH_ROTATE_ROOT_TOKEN\x10\x93\x01\x12\x1f\n\x1b\x43LUSTER_ENTERPRISE_ACTIVATE\x10r\x12 \n\x1c\x43LUSTER_ENTERPRISE_HEARTBEAT\x10s\x12\x1f\n\x1b\x43LUSTER_ENTERPRISE_GET_CODE\x10t\x12!\n\x1d\x43LUSTER_ENTERPRISE_DEACTIVATE\x10u\x12\x1d\n\x18\x43LUSTER_ENTERPRISE_PAUSE\x10\x95\x01\x12\x1f\n\x1b\x43LUSTER_IDENTITY_SET_CONFIG\x10v\x12\x1f\n\x1b\x43LUSTER_IDENTITY_GET_CONFIG\x10w\x12\x1f\n\x1b\x43LUSTER_IDENTITY_CREATE_IDP\x10x\x12\x1f\n\x1b\x43LUSTER_IDENTITY_UPDATE_IDP\x10y\x12\x1e\n\x1a\x43LUSTER_IDENTITY_LIST_IDPS\x10z\x12\x1c\n\x18\x43LUSTER_IDENTITY_GET_IDP\x10{\x12\x1f\n\x1b\x43LUSTER_IDENTITY_DELETE_IDP\x10|\x12\'\n#CLUSTER_IDENTITY_CREATE_OIDC_CLIENT\x10}\x12\'\n#CLUSTER_IDENTITY_UPDATE_OIDC_CLIENT\x10~\x12&\n\"CLUSTER_IDENTITY_LIST_OIDC_CLIENTS\x10\x7f\x12%\n CLUSTER_IDENTITY_GET_OIDC_CLIENT\x10\x80\x01\x12(\n#CLUSTER_IDENTITY_DELETE_OIDC_CLIENT\x10\x81\x01\x12\x17\n\x12\x43LUSTER_DEBUG_DUMP\x10\x83\x01\x12\x1d\n\x18\x43LUSTER_LICENSE_ACTIVATE\x10\x84\x01\x12\x1d\n\x18\x43LUSTER_LICENSE_GET_CODE\x10\x85\x01\x12 \n\x1b\x43LUSTER_LICENSE_ADD_CLUSTER\x10\x86\x01\x12#\n\x1e\x43LUSTER_LICENSE_UPDATE_CLUSTER\x10\x87\x01\x12#\n\x1e\x43LUSTER_LICENSE_DELETE_CLUSTER\x10\x88\x01\x12\"\n\x1d\x43LUSTER_LICENSE_LIST_CLUSTERS\x10\x89\x01\x12\x1a\n\x15\x43LUSTER_CREATE_SECRET\x10\x8f\x01\x12\x19\n\x14\x43LUSTER_LIST_SECRETS\x10\x90\x01\x12\x12\n\rSECRET_DELETE\x10\x91\x01\x12\x13\n\x0eSECRET_INSPECT\x10\x92\x01\x12\x17\n\x12\x43LUSTER_DELETE_ALL\x10\x8a\x01\x12\x0e\n\tREPO_READ\x10\xc8\x01\x12\x0f\n\nREPO_WRITE\x10\xc9\x01\x12\x19\n\x14REPO_MODIFY_BINDINGS\x10\xca\x01\x12\x10\n\x0bREPO_DELETE\x10\xcb\x01\x12\x18\n\x13REPO_INSPECT_COMMIT\x10\xcc\x01\x12\x15\n\x10REPO_LIST_COMMIT\x10\xcd\x01\x12\x17\n\x12REPO_DELETE_COMMIT\x10\xce\x01\x12\x17\n\x12REPO_CREATE_BRANCH\x10\xcf\x01\x12\x15\n\x10REPO_LIST_BRANCH\x10\xd0\x01\x12\x17\n\x12REPO_DELETE_BRANCH\x10\xd1\x01\x12\x16\n\x11REPO_INSPECT_FILE\x10\xd2\x01\x12\x13\n\x0eREPO_LIST_FILE\x10\xd3\x01\x12\x1d\n\x18REPO_ADD_PIPELINE_READER\x10\xd4\x01\x12 \n\x1bREPO_REMOVE_PIPELINE_READER\x10\xd5\x01\x12\x1d\n\x18REPO_ADD_PIPELINE_WRITER\x10\xd6\x01\x12\x16\n\x11PIPELINE_LIST_JOB\x10\xad\x02\x12\x13\n\x0ePROJECT_CREATE\x10\x90\x03\x12\x13\n\x0ePROJECT_DELETE\x10\x91\x03\x12\x16\n\x11PROJECT_LIST_REPO\x10\x92\x03\x12\x18\n\x13PROJECT_CREATE_REPO\x10\x93\x03\x12\x1c\n\x17PROJECT_MODIFY_BINDINGS\x10\x94\x03*\\\n\x0cResourceType\x12\x19\n\x15RESOURCE_TYPE_UNKNOWN\x10\x00\x12\x0b\n\x07\x43LUSTER\x10\x01\x12\x08\n\x04REPO\x10\x02\x12\r\n\tSPEC_REPO\x10\x03\x12\x0b\n\x07PROJECT\x10\x04\x32\xf6\x10\n\x03\x41PI\x12\x41\n\x08\x41\x63tivate\x12\x18.auth_v2.ActivateRequest\x1a\x19.auth_v2.ActivateResponse\"\x00\x12G\n\nDeactivate\x12\x1a.auth_v2.DeactivateRequest\x1a\x1b.auth_v2.DeactivateResponse\"\x00\x12Y\n\x10GetConfiguration\x12 .auth_v2.GetConfigurationRequest\x1a!.auth_v2.GetConfigurationResponse\"\x00\x12Y\n\x10SetConfiguration\x12 .auth_v2.SetConfigurationRequest\x1a!.auth_v2.SetConfigurationResponse\"\x00\x12M\n\x0c\x41uthenticate\x12\x1c.auth_v2.AuthenticateRequest\x1a\x1d.auth_v2.AuthenticateResponse\"\x00\x12\x44\n\tAuthorize\x12\x19.auth_v2.AuthorizeRequest\x1a\x1a.auth_v2.AuthorizeResponse\"\x00\x12S\n\x0eGetPermissions\x12\x1e.auth_v2.GetPermissionsRequest\x1a\x1f.auth_v2.GetPermissionsResponse\"\x00\x12k\n\x1aGetPermissionsForPrincipal\x12*.auth_v2.GetPermissionsForPrincipalRequest\x1a\x1f.auth_v2.GetPermissionsResponse\"\x00\x12;\n\x06WhoAmI\x12\x16.auth_v2.WhoAmIRequest\x1a\x17.auth_v2.WhoAmIResponse\"\x00\x12h\n\x15GetRolesForPermission\x12%.auth_v2.GetRolesForPermissionRequest\x1a&.auth_v2.GetRolesForPermissionResponse\"\x00\x12\\\n\x11ModifyRoleBinding\x12!.auth_v2.ModifyRoleBindingRequest\x1a\".auth_v2.ModifyRoleBindingResponse\"\x00\x12S\n\x0eGetRoleBinding\x12\x1e.auth_v2.GetRoleBindingRequest\x1a\x1f.auth_v2.GetRoleBindingResponse\"\x00\x12M\n\x0cGetOIDCLogin\x12\x1c.auth_v2.GetOIDCLoginRequest\x1a\x1d.auth_v2.GetOIDCLoginResponse\"\x00\x12P\n\rGetRobotToken\x12\x1d.auth_v2.GetRobotTokenRequest\x1a\x1e.auth_v2.GetRobotTokenResponse\"\x00\x12V\n\x0fRevokeAuthToken\x12\x1f.auth_v2.RevokeAuthTokenRequest\x1a .auth_v2.RevokeAuthTokenResponse\"\x00\x12n\n\x17RevokeAuthTokensForUser\x12\'.auth_v2.RevokeAuthTokensForUserRequest\x1a(.auth_v2.RevokeAuthTokensForUserResponse\"\x00\x12Y\n\x10SetGroupsForUser\x12 .auth_v2.SetGroupsForUserRequest\x1a!.auth_v2.SetGroupsForUserResponse\"\x00\x12P\n\rModifyMembers\x12\x1d.auth_v2.ModifyMembersRequest\x1a\x1e.auth_v2.ModifyMembersResponse\"\x00\x12\x44\n\tGetGroups\x12\x19.auth_v2.GetGroupsRequest\x1a\x1a.auth_v2.GetGroupsResponse\"\x00\x12\\\n\x15GetGroupsForPrincipal\x12%.auth_v2.GetGroupsForPrincipalRequest\x1a\x1a.auth_v2.GetGroupsResponse\"\x00\x12\x41\n\x08GetUsers\x12\x18.auth_v2.GetUsersRequest\x1a\x19.auth_v2.GetUsersResponse\"\x00\x12\\\n\x11\x45xtractAuthTokens\x12!.auth_v2.ExtractAuthTokensRequest\x1a\".auth_v2.ExtractAuthTokensResponse\"\x00\x12Y\n\x10RestoreAuthToken\x12 .auth_v2.RestoreAuthTokenRequest\x1a!.auth_v2.RestoreAuthTokenResponse\"\x00\x12n\n\x17\x44\x65leteExpiredAuthTokens\x12\'.auth_v2.DeleteExpiredAuthTokensRequest\x1a(.auth_v2.DeleteExpiredAuthTokensResponse\"\x00\x12V\n\x0fRotateRootToken\x12\x1f.auth_v2.RotateRootTokenRequest\x1a .auth_v2.RotateRootTokenResponse\"\x00\x42,Z*github.com/pachyderm/pachyderm/v2/src/authb\x06proto3'
+  serialized_pb=b'\n)python_pachyderm/proto/v2/auth/auth.proto\x12\x07\x61uth_v2\x1a\x1fgoogle/protobuf/timestamp.proto\"%\n\x0f\x41\x63tivateRequest\x12\x12\n\nroot_token\x18\x01 \x01(\t\"&\n\x10\x41\x63tivateResponse\x12\x12\n\npach_token\x18\x01 \x01(\t\"\x13\n\x11\x44\x65\x61\x63tivateRequest\"\x14\n\x12\x44\x65\x61\x63tivateResponse\",\n\x16RotateRootTokenRequest\x12\x12\n\nroot_token\x18\x01 \x01(\t\"-\n\x17RotateRootTokenResponse\x12\x12\n\nroot_token\x18\x01 \x01(\t\"\xcb\x01\n\nOIDCConfig\x12\x0e\n\x06issuer\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\x12\x15\n\rclient_secret\x18\x03 \x01(\t\x12\x14\n\x0credirect_uri\x18\x04 \x01(\t\x12\x0e\n\x06scopes\x18\x05 \x03(\t\x12\x1e\n\x16require_email_verified\x18\x06 \x01(\x08\x12\x18\n\x10localhost_issuer\x18\x07 \x01(\x08\x12#\n\x1buser_accessible_issuer_host\x18\x08 \x01(\t\"\x19\n\x17GetConfigurationRequest\"F\n\x18GetConfigurationResponse\x12*\n\rconfiguration\x18\x01 \x01(\x0b\x32\x13.auth_v2.OIDCConfig\"E\n\x17SetConfigurationRequest\x12*\n\rconfiguration\x18\x01 \x01(\x0b\x32\x13.auth_v2.OIDCConfig\"\x1a\n\x18SetConfigurationResponse\"b\n\tTokenInfo\x12\x0f\n\x07subject\x18\x01 \x01(\t\x12.\n\nexpiration\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x14\n\x0chashed_token\x18\x03 \x01(\t\";\n\x13\x41uthenticateRequest\x12\x12\n\noidc_state\x18\x01 \x01(\t\x12\x10\n\x08id_token\x18\x02 \x01(\t\"*\n\x14\x41uthenticateResponse\x12\x12\n\npach_token\x18\x01 \x01(\t\"\x0f\n\rWhoAmIRequest\"R\n\x0eWhoAmIResponse\x12\x10\n\x08username\x18\x01 \x01(\t\x12.\n\nexpiration\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"G\n\x1cGetRolesForPermissionRequest\x12\'\n\npermission\x18\x01 \x01(\x0e\x32\x13.auth_v2.Permission\"=\n\x1dGetRolesForPermissionResponse\x12\x1c\n\x05roles\x18\x01 \x03(\x0b\x32\r.auth_v2.Role\"_\n\x05Roles\x12(\n\x05roles\x18\x01 \x03(\x0b\x32\x19.auth_v2.Roles.RolesEntry\x1a,\n\nRolesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"\x81\x01\n\x0bRoleBinding\x12\x32\n\x07\x65ntries\x18\x01 \x03(\x0b\x32!.auth_v2.RoleBinding.EntriesEntry\x1a>\n\x0c\x45ntriesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1d\n\x05value\x18\x02 \x01(\x0b\x32\x0e.auth_v2.Roles:\x02\x38\x01\"=\n\x08Resource\x12#\n\x04type\x18\x01 \x01(\x0e\x32\x15.auth_v2.ResourceType\x12\x0c\n\x04name\x18\x02 \x01(\t\"k\n\x05Users\x12\x30\n\tusernames\x18\x01 \x03(\x0b\x32\x1d.auth_v2.Users.UsernamesEntry\x1a\x30\n\x0eUsernamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"d\n\x06Groups\x12+\n\x06groups\x18\x01 \x03(\x0b\x32\x1b.auth_v2.Groups.GroupsEntry\x1a-\n\x0bGroupsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"\x9b\x01\n\x04Role\x12\x0c\n\x04name\x18\x01 \x01(\t\x12(\n\x0bpermissions\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\x12.\n\x0f\x63\x61n_be_bound_to\x18\x03 \x03(\x0e\x32\x15.auth_v2.ResourceType\x12+\n\x0creturned_for\x18\x04 \x03(\x0e\x32\x15.auth_v2.ResourceType\"a\n\x10\x41uthorizeRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12(\n\x0bpermissions\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\"\x88\x01\n\x11\x41uthorizeResponse\x12\x12\n\nauthorized\x18\x01 \x01(\x08\x12&\n\tsatisfied\x18\x02 \x03(\x0e\x32\x13.auth_v2.Permission\x12$\n\x07missing\x18\x03 \x03(\x0e\x32\x13.auth_v2.Permission\x12\x11\n\tprincipal\x18\x04 \x01(\t\"<\n\x15GetPermissionsRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\"[\n!GetPermissionsForPrincipalRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12\x11\n\tprincipal\x18\x02 \x01(\t\"Q\n\x16GetPermissionsResponse\x12(\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x13.auth_v2.Permission\x12\r\n\x05roles\x18\x02 \x03(\t\"a\n\x18ModifyRoleBindingRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\x12\x11\n\tprincipal\x18\x02 \x01(\t\x12\r\n\x05roles\x18\x03 \x03(\t\"\x1b\n\x19ModifyRoleBindingResponse\"<\n\x15GetRoleBindingRequest\x12#\n\x08resource\x18\x01 \x01(\x0b\x32\x11.auth_v2.Resource\"?\n\x16GetRoleBindingResponse\x12%\n\x07\x62inding\x18\x01 \x01(\x0b\x32\x14.auth_v2.RoleBinding\"C\n\x0bSessionInfo\x12\r\n\x05nonce\x18\x01 \x01(\t\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x16\n\x0e\x63onversion_err\x18\x03 \x01(\x08\"\x15\n\x13GetOIDCLoginRequest\"8\n\x14GetOIDCLoginResponse\x12\x11\n\tlogin_url\x18\x01 \x01(\t\x12\r\n\x05state\x18\x02 \x01(\t\"2\n\x14GetRobotTokenRequest\x12\r\n\x05robot\x18\x01 \x01(\t\x12\x0b\n\x03ttl\x18\x02 \x01(\x03\"&\n\x15GetRobotTokenResponse\x12\r\n\x05token\x18\x01 \x01(\t\"\'\n\x16RevokeAuthTokenRequest\x12\r\n\x05token\x18\x01 \x01(\t\")\n\x17RevokeAuthTokenResponse\x12\x0e\n\x06number\x18\x01 \x01(\x03\";\n\x17SetGroupsForUserRequest\x12\x10\n\x08username\x18\x01 \x01(\t\x12\x0e\n\x06groups\x18\x02 \x03(\t\"\x1a\n\x18SetGroupsForUserResponse\"B\n\x14ModifyMembersRequest\x12\r\n\x05group\x18\x01 \x01(\t\x12\x0b\n\x03\x61\x64\x64\x18\x02 \x03(\t\x12\x0e\n\x06remove\x18\x03 \x03(\t\"\x17\n\x15ModifyMembersResponse\"\x12\n\x10GetGroupsRequest\"1\n\x1cGetGroupsForPrincipalRequest\x12\x11\n\tprincipal\x18\x01 \x01(\t\"#\n\x11GetGroupsResponse\x12\x0e\n\x06groups\x18\x01 \x03(\t\" \n\x0fGetUsersRequest\x12\r\n\x05group\x18\x01 \x01(\t\"%\n\x10GetUsersResponse\x12\x11\n\tusernames\x18\x01 \x03(\t\"\x1a\n\x18\x45xtractAuthTokensRequest\"?\n\x19\x45xtractAuthTokensResponse\x12\"\n\x06tokens\x18\x01 \x03(\x0b\x32\x12.auth_v2.TokenInfo\"<\n\x17RestoreAuthTokenRequest\x12!\n\x05token\x18\x01 \x01(\x0b\x32\x12.auth_v2.TokenInfo\"\x1a\n\x18RestoreAuthTokenResponse\"2\n\x1eRevokeAuthTokensForUserRequest\x12\x10\n\x08username\x18\x01 \x01(\t\"1\n\x1fRevokeAuthTokensForUserResponse\x12\x0e\n\x06number\x18\x01 \x01(\x03\" \n\x1e\x44\x65leteExpiredAuthTokensRequest\"!\n\x1f\x44\x65leteExpiredAuthTokensResponse*\xa9\x10\n\nPermission\x12\x16\n\x12PERMISSION_UNKNOWN\x10\x00\x12\x1b\n\x17\x43LUSTER_MODIFY_BINDINGS\x10\x64\x12\x18\n\x14\x43LUSTER_GET_BINDINGS\x10\x65\x12\x1b\n\x16\x43LUSTER_GET_PACHD_LOGS\x10\x94\x01\x12\x1a\n\x15\x43LUSTER_GET_LOKI_LOGS\x10\x96\x01\x12\x19\n\x15\x43LUSTER_AUTH_ACTIVATE\x10\x66\x12\x1b\n\x17\x43LUSTER_AUTH_DEACTIVATE\x10g\x12\x1b\n\x17\x43LUSTER_AUTH_GET_CONFIG\x10h\x12\x1b\n\x17\x43LUSTER_AUTH_SET_CONFIG\x10i\x12!\n\x1c\x43LUSTER_AUTH_GET_ROBOT_TOKEN\x10\x8b\x01\x12%\n!CLUSTER_AUTH_MODIFY_GROUP_MEMBERS\x10m\x12\x1b\n\x17\x43LUSTER_AUTH_GET_GROUPS\x10n\x12 \n\x1c\x43LUSTER_AUTH_GET_GROUP_USERS\x10o\x12\x1f\n\x1b\x43LUSTER_AUTH_EXTRACT_TOKENS\x10p\x12\x1e\n\x1a\x43LUSTER_AUTH_RESTORE_TOKEN\x10q\x12/\n*CLUSTER_AUTH_GET_PERMISSIONS_FOR_PRINCIPAL\x10\x8d\x01\x12\'\n\"CLUSTER_AUTH_DELETE_EXPIRED_TOKENS\x10\x8c\x01\x12$\n\x1f\x43LUSTER_AUTH_REVOKE_USER_TOKENS\x10\x8e\x01\x12#\n\x1e\x43LUSTER_AUTH_ROTATE_ROOT_TOKEN\x10\x93\x01\x12\x1f\n\x1b\x43LUSTER_ENTERPRISE_ACTIVATE\x10r\x12 \n\x1c\x43LUSTER_ENTERPRISE_HEARTBEAT\x10s\x12\x1f\n\x1b\x43LUSTER_ENTERPRISE_GET_CODE\x10t\x12!\n\x1d\x43LUSTER_ENTERPRISE_DEACTIVATE\x10u\x12\x1d\n\x18\x43LUSTER_ENTERPRISE_PAUSE\x10\x95\x01\x12\x1f\n\x1b\x43LUSTER_IDENTITY_SET_CONFIG\x10v\x12\x1f\n\x1b\x43LUSTER_IDENTITY_GET_CONFIG\x10w\x12\x1f\n\x1b\x43LUSTER_IDENTITY_CREATE_IDP\x10x\x12\x1f\n\x1b\x43LUSTER_IDENTITY_UPDATE_IDP\x10y\x12\x1e\n\x1a\x43LUSTER_IDENTITY_LIST_IDPS\x10z\x12\x1c\n\x18\x43LUSTER_IDENTITY_GET_IDP\x10{\x12\x1f\n\x1b\x43LUSTER_IDENTITY_DELETE_IDP\x10|\x12\'\n#CLUSTER_IDENTITY_CREATE_OIDC_CLIENT\x10}\x12\'\n#CLUSTER_IDENTITY_UPDATE_OIDC_CLIENT\x10~\x12&\n\"CLUSTER_IDENTITY_LIST_OIDC_CLIENTS\x10\x7f\x12%\n CLUSTER_IDENTITY_GET_OIDC_CLIENT\x10\x80\x01\x12(\n#CLUSTER_IDENTITY_DELETE_OIDC_CLIENT\x10\x81\x01\x12\x17\n\x12\x43LUSTER_DEBUG_DUMP\x10\x83\x01\x12\x1d\n\x18\x43LUSTER_LICENSE_ACTIVATE\x10\x84\x01\x12\x1d\n\x18\x43LUSTER_LICENSE_GET_CODE\x10\x85\x01\x12 \n\x1b\x43LUSTER_LICENSE_ADD_CLUSTER\x10\x86\x01\x12#\n\x1e\x43LUSTER_LICENSE_UPDATE_CLUSTER\x10\x87\x01\x12#\n\x1e\x43LUSTER_LICENSE_DELETE_CLUSTER\x10\x88\x01\x12\"\n\x1d\x43LUSTER_LICENSE_LIST_CLUSTERS\x10\x89\x01\x12\x1a\n\x15\x43LUSTER_CREATE_SECRET\x10\x8f\x01\x12\x19\n\x14\x43LUSTER_LIST_SECRETS\x10\x90\x01\x12\x12\n\rSECRET_DELETE\x10\x91\x01\x12\x13\n\x0eSECRET_INSPECT\x10\x92\x01\x12\x17\n\x12\x43LUSTER_DELETE_ALL\x10\x8a\x01\x12\x0e\n\tREPO_READ\x10\xc8\x01\x12\x0f\n\nREPO_WRITE\x10\xc9\x01\x12\x19\n\x14REPO_MODIFY_BINDINGS\x10\xca\x01\x12\x10\n\x0bREPO_DELETE\x10\xcb\x01\x12\x18\n\x13REPO_INSPECT_COMMIT\x10\xcc\x01\x12\x15\n\x10REPO_LIST_COMMIT\x10\xcd\x01\x12\x17\n\x12REPO_DELETE_COMMIT\x10\xce\x01\x12\x17\n\x12REPO_CREATE_BRANCH\x10\xcf\x01\x12\x15\n\x10REPO_LIST_BRANCH\x10\xd0\x01\x12\x17\n\x12REPO_DELETE_BRANCH\x10\xd1\x01\x12\x16\n\x11REPO_INSPECT_FILE\x10\xd2\x01\x12\x13\n\x0eREPO_LIST_FILE\x10\xd3\x01\x12\x1d\n\x18REPO_ADD_PIPELINE_READER\x10\xd4\x01\x12 \n\x1bREPO_REMOVE_PIPELINE_READER\x10\xd5\x01\x12\x1d\n\x18REPO_ADD_PIPELINE_WRITER\x10\xd6\x01\x12\x16\n\x11PIPELINE_LIST_JOB\x10\xad\x02\x12\x13\n\x0ePROJECT_CREATE\x10\x90\x03\x12\x13\n\x0ePROJECT_DELETE\x10\x91\x03\x12\x16\n\x11PROJECT_LIST_REPO\x10\x92\x03\x12\x18\n\x13PROJECT_CREATE_REPO\x10\x93\x03\x12\x1c\n\x17PROJECT_MODIFY_BINDINGS\x10\x94\x03*\\\n\x0cResourceType\x12\x19\n\x15RESOURCE_TYPE_UNKNOWN\x10\x00\x12\x0b\n\x07\x43LUSTER\x10\x01\x12\x08\n\x04REPO\x10\x02\x12\r\n\tSPEC_REPO\x10\x03\x12\x0b\n\x07PROJECT\x10\x04\x32\xf6\x10\n\x03\x41PI\x12\x41\n\x08\x41\x63tivate\x12\x18.auth_v2.ActivateRequest\x1a\x19.auth_v2.ActivateResponse\"\x00\x12G\n\nDeactivate\x12\x1a.auth_v2.DeactivateRequest\x1a\x1b.auth_v2.DeactivateResponse\"\x00\x12Y\n\x10GetConfiguration\x12 .auth_v2.GetConfigurationRequest\x1a!.auth_v2.GetConfigurationResponse\"\x00\x12Y\n\x10SetConfiguration\x12 .auth_v2.SetConfigurationRequest\x1a!.auth_v2.SetConfigurationResponse\"\x00\x12M\n\x0c\x41uthenticate\x12\x1c.auth_v2.AuthenticateRequest\x1a\x1d.auth_v2.AuthenticateResponse\"\x00\x12\x44\n\tAuthorize\x12\x19.auth_v2.AuthorizeRequest\x1a\x1a.auth_v2.AuthorizeResponse\"\x00\x12S\n\x0eGetPermissions\x12\x1e.auth_v2.GetPermissionsRequest\x1a\x1f.auth_v2.GetPermissionsResponse\"\x00\x12k\n\x1aGetPermissionsForPrincipal\x12*.auth_v2.GetPermissionsForPrincipalRequest\x1a\x1f.auth_v2.GetPermissionsResponse\"\x00\x12;\n\x06WhoAmI\x12\x16.auth_v2.WhoAmIRequest\x1a\x17.auth_v2.WhoAmIResponse\"\x00\x12h\n\x15GetRolesForPermission\x12%.auth_v2.GetRolesForPermissionRequest\x1a&.auth_v2.GetRolesForPermissionResponse\"\x00\x12\\\n\x11ModifyRoleBinding\x12!.auth_v2.ModifyRoleBindingRequest\x1a\".auth_v2.ModifyRoleBindingResponse\"\x00\x12S\n\x0eGetRoleBinding\x12\x1e.auth_v2.GetRoleBindingRequest\x1a\x1f.auth_v2.GetRoleBindingResponse\"\x00\x12M\n\x0cGetOIDCLogin\x12\x1c.auth_v2.GetOIDCLoginRequest\x1a\x1d.auth_v2.GetOIDCLoginResponse\"\x00\x12P\n\rGetRobotToken\x12\x1d.auth_v2.GetRobotTokenRequest\x1a\x1e.auth_v2.GetRobotTokenResponse\"\x00\x12V\n\x0fRevokeAuthToken\x12\x1f.auth_v2.RevokeAuthTokenRequest\x1a .auth_v2.RevokeAuthTokenResponse\"\x00\x12n\n\x17RevokeAuthTokensForUser\x12\'.auth_v2.RevokeAuthTokensForUserRequest\x1a(.auth_v2.RevokeAuthTokensForUserResponse\"\x00\x12Y\n\x10SetGroupsForUser\x12 .auth_v2.SetGroupsForUserRequest\x1a!.auth_v2.SetGroupsForUserResponse\"\x00\x12P\n\rModifyMembers\x12\x1d.auth_v2.ModifyMembersRequest\x1a\x1e.auth_v2.ModifyMembersResponse\"\x00\x12\x44\n\tGetGroups\x12\x19.auth_v2.GetGroupsRequest\x1a\x1a.auth_v2.GetGroupsResponse\"\x00\x12\\\n\x15GetGroupsForPrincipal\x12%.auth_v2.GetGroupsForPrincipalRequest\x1a\x1a.auth_v2.GetGroupsResponse\"\x00\x12\x41\n\x08GetUsers\x12\x18.auth_v2.GetUsersRequest\x1a\x19.auth_v2.GetUsersResponse\"\x00\x12\\\n\x11\x45xtractAuthTokens\x12!.auth_v2.ExtractAuthTokensRequest\x1a\".auth_v2.ExtractAuthTokensResponse\"\x00\x12Y\n\x10RestoreAuthToken\x12 .auth_v2.RestoreAuthTokenRequest\x1a!.auth_v2.RestoreAuthTokenResponse\"\x00\x12n\n\x17\x44\x65leteExpiredAuthTokens\x12\'.auth_v2.DeleteExpiredAuthTokensRequest\x1a(.auth_v2.DeleteExpiredAuthTokensResponse\"\x00\x12V\n\x0fRotateRootToken\x12\x1f.auth_v2.RotateRootTokenRequest\x1a .auth_v2.RotateRootTokenResponse\"\x00\x42,Z*github.com/pachyderm/pachyderm/v2/src/authb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
@@ -380,8 +380,8 @@ _PERMISSION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3538,
-  serialized_end=5627,
+  serialized_start=3585,
+  serialized_end=5674,
 )
 _sym_db.RegisterEnumDescriptor(_PERMISSION)
 
@@ -421,8 +421,8 @@ _RESOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=5629,
-  serialized_end=5721,
+  serialized_start=5676,
+  serialized_end=5768,
 )
 _sym_db.RegisterEnumDescriptor(_RESOURCETYPE)
 
@@ -1464,8 +1464,15 @@ _ROLE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='resource_types', full_name='auth_v2.Role.resource_types', index=2,
+      name='can_be_bound_to', full_name='auth_v2.Role.can_be_bound_to', index=2,
       number=3, type=14, cpp_type=8, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='returned_for', full_name='auth_v2.Role.returned_for', index=3,
+      number=4, type=14, cpp_type=8, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1482,8 +1489,8 @@ _ROLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1651,
-  serialized_end=1760,
+  serialized_start=1652,
+  serialized_end=1807,
 )
 
 
@@ -1521,8 +1528,8 @@ _AUTHORIZEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1762,
-  serialized_end=1859,
+  serialized_start=1809,
+  serialized_end=1906,
 )
 
 
@@ -1574,8 +1581,8 @@ _AUTHORIZERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1862,
-  serialized_end=1998,
+  serialized_start=1909,
+  serialized_end=2045,
 )
 
 
@@ -1606,8 +1613,8 @@ _GETPERMISSIONSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2000,
-  serialized_end=2060,
+  serialized_start=2047,
+  serialized_end=2107,
 )
 
 
@@ -1645,8 +1652,8 @@ _GETPERMISSIONSFORPRINCIPALREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2062,
-  serialized_end=2153,
+  serialized_start=2109,
+  serialized_end=2200,
 )
 
 
@@ -1684,8 +1691,8 @@ _GETPERMISSIONSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2155,
-  serialized_end=2236,
+  serialized_start=2202,
+  serialized_end=2283,
 )
 
 
@@ -1730,8 +1737,8 @@ _MODIFYROLEBINDINGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2238,
-  serialized_end=2335,
+  serialized_start=2285,
+  serialized_end=2382,
 )
 
 
@@ -1755,8 +1762,8 @@ _MODIFYROLEBINDINGRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2337,
-  serialized_end=2364,
+  serialized_start=2384,
+  serialized_end=2411,
 )
 
 
@@ -1787,8 +1794,8 @@ _GETROLEBINDINGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2366,
-  serialized_end=2426,
+  serialized_start=2413,
+  serialized_end=2473,
 )
 
 
@@ -1819,8 +1826,8 @@ _GETROLEBINDINGRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2428,
-  serialized_end=2491,
+  serialized_start=2475,
+  serialized_end=2538,
 )
 
 
@@ -1865,8 +1872,8 @@ _SESSIONINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2493,
-  serialized_end=2560,
+  serialized_start=2540,
+  serialized_end=2607,
 )
 
 
@@ -1890,8 +1897,8 @@ _GETOIDCLOGINREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2562,
-  serialized_end=2583,
+  serialized_start=2609,
+  serialized_end=2630,
 )
 
 
@@ -1929,8 +1936,8 @@ _GETOIDCLOGINRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2585,
-  serialized_end=2641,
+  serialized_start=2632,
+  serialized_end=2688,
 )
 
 
@@ -1968,8 +1975,8 @@ _GETROBOTTOKENREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2643,
-  serialized_end=2693,
+  serialized_start=2690,
+  serialized_end=2740,
 )
 
 
@@ -2000,8 +2007,8 @@ _GETROBOTTOKENRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2695,
-  serialized_end=2733,
+  serialized_start=2742,
+  serialized_end=2780,
 )
 
 
@@ -2032,8 +2039,8 @@ _REVOKEAUTHTOKENREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2735,
-  serialized_end=2774,
+  serialized_start=2782,
+  serialized_end=2821,
 )
 
 
@@ -2064,8 +2071,8 @@ _REVOKEAUTHTOKENRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2776,
-  serialized_end=2817,
+  serialized_start=2823,
+  serialized_end=2864,
 )
 
 
@@ -2103,8 +2110,8 @@ _SETGROUPSFORUSERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2819,
-  serialized_end=2878,
+  serialized_start=2866,
+  serialized_end=2925,
 )
 
 
@@ -2128,8 +2135,8 @@ _SETGROUPSFORUSERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2880,
-  serialized_end=2906,
+  serialized_start=2927,
+  serialized_end=2953,
 )
 
 
@@ -2174,8 +2181,8 @@ _MODIFYMEMBERSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2908,
-  serialized_end=2974,
+  serialized_start=2955,
+  serialized_end=3021,
 )
 
 
@@ -2199,8 +2206,8 @@ _MODIFYMEMBERSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2976,
-  serialized_end=2999,
+  serialized_start=3023,
+  serialized_end=3046,
 )
 
 
@@ -2224,8 +2231,8 @@ _GETGROUPSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3001,
-  serialized_end=3019,
+  serialized_start=3048,
+  serialized_end=3066,
 )
 
 
@@ -2256,8 +2263,8 @@ _GETGROUPSFORPRINCIPALREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3021,
-  serialized_end=3070,
+  serialized_start=3068,
+  serialized_end=3117,
 )
 
 
@@ -2288,8 +2295,8 @@ _GETGROUPSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3072,
-  serialized_end=3107,
+  serialized_start=3119,
+  serialized_end=3154,
 )
 
 
@@ -2320,8 +2327,8 @@ _GETUSERSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3109,
-  serialized_end=3141,
+  serialized_start=3156,
+  serialized_end=3188,
 )
 
 
@@ -2352,8 +2359,8 @@ _GETUSERSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3143,
-  serialized_end=3180,
+  serialized_start=3190,
+  serialized_end=3227,
 )
 
 
@@ -2377,8 +2384,8 @@ _EXTRACTAUTHTOKENSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3182,
-  serialized_end=3208,
+  serialized_start=3229,
+  serialized_end=3255,
 )
 
 
@@ -2409,8 +2416,8 @@ _EXTRACTAUTHTOKENSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3210,
-  serialized_end=3273,
+  serialized_start=3257,
+  serialized_end=3320,
 )
 
 
@@ -2441,8 +2448,8 @@ _RESTOREAUTHTOKENREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3275,
-  serialized_end=3335,
+  serialized_start=3322,
+  serialized_end=3382,
 )
 
 
@@ -2466,8 +2473,8 @@ _RESTOREAUTHTOKENRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3337,
-  serialized_end=3363,
+  serialized_start=3384,
+  serialized_end=3410,
 )
 
 
@@ -2498,8 +2505,8 @@ _REVOKEAUTHTOKENSFORUSERREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3365,
-  serialized_end=3415,
+  serialized_start=3412,
+  serialized_end=3462,
 )
 
 
@@ -2530,8 +2537,8 @@ _REVOKEAUTHTOKENSFORUSERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3417,
-  serialized_end=3466,
+  serialized_start=3464,
+  serialized_end=3513,
 )
 
 
@@ -2555,8 +2562,8 @@ _DELETEEXPIREDAUTHTOKENSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3468,
-  serialized_end=3500,
+  serialized_start=3515,
+  serialized_end=3547,
 )
 
 
@@ -2580,8 +2587,8 @@ _DELETEEXPIREDAUTHTOKENSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3502,
-  serialized_end=3535,
+  serialized_start=3549,
+  serialized_end=3582,
 )
 
 _GETCONFIGURATIONRESPONSE.fields_by_name['configuration'].message_type = _OIDCCONFIG
@@ -2601,7 +2608,8 @@ _USERS.fields_by_name['usernames'].message_type = _USERS_USERNAMESENTRY
 _GROUPS_GROUPSENTRY.containing_type = _GROUPS
 _GROUPS.fields_by_name['groups'].message_type = _GROUPS_GROUPSENTRY
 _ROLE.fields_by_name['permissions'].enum_type = _PERMISSION
-_ROLE.fields_by_name['resource_types'].enum_type = _RESOURCETYPE
+_ROLE.fields_by_name['can_be_bound_to'].enum_type = _RESOURCETYPE
+_ROLE.fields_by_name['returned_for'].enum_type = _RESOURCETYPE
 _AUTHORIZEREQUEST.fields_by_name['resource'].message_type = _RESOURCE
 _AUTHORIZEREQUEST.fields_by_name['permissions'].enum_type = _PERMISSION
 _AUTHORIZERESPONSE.fields_by_name['satisfied'].enum_type = _PERMISSION
@@ -3120,8 +3128,8 @@ _API = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=5724,
-  serialized_end=7890,
+  serialized_start=5771,
+  serialized_end=7937,
   methods=[
   _descriptor.MethodDescriptor(
     name='Activate',

--- a/src/python_pachyderm/proto/v2/debug/debug_pb2.py
+++ b/src/python_pachyderm/proto/v2/debug/debug_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z+github.com/pachyderm/pachyderm/v2/src/debug',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n+python_pachyderm/proto/v2/debug/debug.proto\x12\x08\x64\x65\x62ug_v2\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\'python_pachyderm/proto/v2/pps/pps.proto\"V\n\x0eProfileRequest\x12\"\n\x07profile\x18\x01 \x01(\x0b\x32\x11.debug_v2.Profile\x12 \n\x06\x66ilter\x18\x02 \x01(\x0b\x32\x10.debug_v2.Filter\"D\n\x07Profile\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\x08\x64uration\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\"\x81\x01\n\x06\x46ilter\x12\x0f\n\x05pachd\x18\x01 \x01(\x08H\x00\x12$\n\x08pipeline\x18\x02 \x01(\x0b\x32\x10.pps_v2.PipelineH\x00\x12\"\n\x06worker\x18\x03 \x01(\x0b\x32\x10.debug_v2.WorkerH\x00\x12\x12\n\x08\x64\x61tabase\x18\x04 \x01(\x08H\x00\x42\x08\n\x06\x66ilter\")\n\x06Worker\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x12\n\nredirected\x18\x02 \x01(\x08\"1\n\rBinaryRequest\x12 \n\x06\x66ilter\x18\x01 \x01(\x0b\x32\x10.debug_v2.Filter\">\n\x0b\x44umpRequest\x12 \n\x06\x66ilter\x18\x01 \x01(\x0b\x32\x10.debug_v2.Filter\x12\r\n\x05limit\x18\x02 \x01(\x03\"\x90\x02\n\x12SetLogLevelRequest\x12:\n\tpachyderm\x18\x01 \x01(\x0e\x32%.debug_v2.SetLogLevelRequest.LogLevelH\x00\x12\x35\n\x04grpc\x18\x02 \x01(\x0e\x32%.debug_v2.SetLogLevelRequest.LogLevelH\x00\x12+\n\x08\x64uration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x0f\n\x07recurse\x18\x04 \x01(\x08\"@\n\x08LogLevel\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x07\n\x03OFF\x10\x04\x42\x07\n\x05level\"B\n\x13SetLogLevelResponse\x12\x15\n\raffected_pods\x18\x01 \x03(\t\x12\x14\n\x0c\x65rrored_pods\x18\x02 \x03(\t2\x9f\x02\n\x05\x44\x65\x62ug\x12\x44\n\x07Profile\x12\x18.debug_v2.ProfileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12\x42\n\x06\x42inary\x12\x17.debug_v2.BinaryRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12>\n\x04\x44ump\x12\x15.debug_v2.DumpRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12L\n\x0bSetLogLevel\x12\x1c.debug_v2.SetLogLevelRequest\x1a\x1d.debug_v2.SetLogLevelResponse\"\x00\x42-Z+github.com/pachyderm/pachyderm/v2/src/debugb\x06proto3'
+  serialized_pb=b'\n+python_pachyderm/proto/v2/debug/debug.proto\x12\x08\x64\x65\x62ug_v2\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\'python_pachyderm/proto/v2/pps/pps.proto\"V\n\x0eProfileRequest\x12\"\n\x07profile\x18\x01 \x01(\x0b\x32\x11.debug_v2.Profile\x12 \n\x06\x66ilter\x18\x02 \x01(\x0b\x32\x10.debug_v2.Filter\"D\n\x07Profile\x12\x0c\n\x04name\x18\x01 \x01(\t\x12+\n\x08\x64uration\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\"\x81\x01\n\x06\x46ilter\x12\x0f\n\x05pachd\x18\x01 \x01(\x08H\x00\x12$\n\x08pipeline\x18\x02 \x01(\x0b\x32\x10.pps_v2.PipelineH\x00\x12\"\n\x06worker\x18\x03 \x01(\x0b\x32\x10.debug_v2.WorkerH\x00\x12\x12\n\x08\x64\x61tabase\x18\x04 \x01(\x08H\x00\x42\x08\n\x06\x66ilter\")\n\x06Worker\x12\x0b\n\x03pod\x18\x01 \x01(\t\x12\x12\n\nredirected\x18\x02 \x01(\x08\"1\n\rBinaryRequest\x12 \n\x06\x66ilter\x18\x01 \x01(\x0b\x32\x10.debug_v2.Filter\">\n\x0b\x44umpRequest\x12 \n\x06\x66ilter\x18\x01 \x01(\x0b\x32\x10.debug_v2.Filter\x12\r\n\x05limit\x18\x02 \x01(\x03\"\x90\x02\n\x12SetLogLevelRequest\x12:\n\tpachyderm\x18\x01 \x01(\x0e\x32%.debug_v2.SetLogLevelRequest.LogLevelH\x00\x12\x35\n\x04grpc\x18\x02 \x01(\x0e\x32%.debug_v2.SetLogLevelRequest.LogLevelH\x00\x12+\n\x08\x64uration\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x0f\n\x07recurse\x18\x04 \x01(\x08\"@\n\x08LogLevel\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x07\n\x03OFF\x10\x04\x42\x07\n\x05level\"B\n\x13SetLogLevelResponse\x12\x15\n\raffected_pods\x18\x01 \x03(\t\x12\x14\n\x0c\x65rrored_pods\x18\x02 \x03(\t\"+\n\x18GetDumpV2TemplateRequest\x12\x0f\n\x07\x66ilters\x18\x01 \x03(\t\"E\n\x19GetDumpV2TemplateResponse\x12(\n\x07request\x18\x01 \x01(\x0b\x32\x17.debug_v2.DumpV2Request\")\n\x08Pipeline\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"3\n\x03Pod\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\n\n\x02ip\x18\x02 \x01(\t\x12\x12\n\ncontainers\x18\x03 \x03(\t\"\x82\x01\n\x03\x41pp\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1b\n\x04pods\x18\x02 \x03(\x0b\x32\r.debug_v2.Pod\x12*\n\x07timeout\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12$\n\x08pipeline\x18\x04 \x01(\x0b\x32\x12.debug_v2.Pipeline\"\xdc\x01\n\x06System\x12\x0c\n\x04helm\x18\x01 \x01(\x08\x12\x10\n\x08\x64\x61tabase\x18\x02 \x01(\x08\x12\x0f\n\x07version\x18\x03 \x01(\x08\x12 \n\tdescribes\x18\x04 \x03(\x0b\x32\r.debug_v2.App\x12\x1b\n\x04logs\x18\x05 \x03(\x0b\x32\r.debug_v2.App\x12 \n\tloki_logs\x18\x06 \x03(\x0b\x32\r.debug_v2.App\x12\x1f\n\x08\x62inaries\x18\x07 \x03(\x0b\x32\r.debug_v2.App\x12\x1f\n\x08profiles\x18\x08 \x03(\x0b\x32\r.debug_v2.App\"\x99\x01\n\rDumpV2Request\x12 \n\x06system\x18\x01 \x01(\x0b\x32\x10.debug_v2.System\x12%\n\tpipelines\x18\x02 \x03(\x0b\x32\x12.debug_v2.Pipeline\x12\x13\n\x0binput_repos\x18\x03 \x01(\x08\x12*\n\x07timeout\x18\x04 \x01(\x0b\x32\x19.google.protobuf.Duration\"\x1e\n\x0b\x44umpContent\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\x0c\"=\n\x0c\x44umpProgress\x12\x0c\n\x04task\x18\x01 \x01(\t\x12\r\n\x05total\x18\x02 \x01(\x03\x12\x10\n\x08progress\x18\x03 \x01(\x03\"j\n\tDumpChunk\x12(\n\x07\x63ontent\x18\x01 \x01(\x0b\x32\x15.debug_v2.DumpContentH\x00\x12*\n\x08progress\x18\x02 \x01(\x0b\x32\x16.debug_v2.DumpProgressH\x00\x42\x07\n\x05\x63hunk2\xbb\x03\n\x05\x44\x65\x62ug\x12\x44\n\x07Profile\x12\x18.debug_v2.ProfileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12\x42\n\x06\x42inary\x12\x17.debug_v2.BinaryRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12>\n\x04\x44ump\x12\x15.debug_v2.DumpRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12L\n\x0bSetLogLevel\x12\x1c.debug_v2.SetLogLevelRequest\x1a\x1d.debug_v2.SetLogLevelResponse\"\x00\x12^\n\x11GetDumpV2Template\x12\".debug_v2.GetDumpV2TemplateRequest\x1a#.debug_v2.GetDumpV2TemplateResponse\"\x00\x12:\n\x06\x44umpV2\x12\x17.debug_v2.DumpV2Request\x1a\x13.debug_v2.DumpChunk\"\x00\x30\x01\x42-Z+github.com/pachyderm/pachyderm/v2/src/debugb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_pps_dot_pps__pb2.DESCRIPTOR,])
 
@@ -412,6 +412,464 @@ _SETLOGLEVELRESPONSE = _descriptor.Descriptor(
   serialized_end=951,
 )
 
+
+_GETDUMPV2TEMPLATEREQUEST = _descriptor.Descriptor(
+  name='GetDumpV2TemplateRequest',
+  full_name='debug_v2.GetDumpV2TemplateRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='filters', full_name='debug_v2.GetDumpV2TemplateRequest.filters', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=953,
+  serialized_end=996,
+)
+
+
+_GETDUMPV2TEMPLATERESPONSE = _descriptor.Descriptor(
+  name='GetDumpV2TemplateResponse',
+  full_name='debug_v2.GetDumpV2TemplateResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='request', full_name='debug_v2.GetDumpV2TemplateResponse.request', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=998,
+  serialized_end=1067,
+)
+
+
+_PIPELINE = _descriptor.Descriptor(
+  name='Pipeline',
+  full_name='debug_v2.Pipeline',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='project', full_name='debug_v2.Pipeline.project', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='name', full_name='debug_v2.Pipeline.name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1069,
+  serialized_end=1110,
+)
+
+
+_POD = _descriptor.Descriptor(
+  name='Pod',
+  full_name='debug_v2.Pod',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='debug_v2.Pod.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ip', full_name='debug_v2.Pod.ip', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='containers', full_name='debug_v2.Pod.containers', index=2,
+      number=3, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1112,
+  serialized_end=1163,
+)
+
+
+_APP = _descriptor.Descriptor(
+  name='App',
+  full_name='debug_v2.App',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='debug_v2.App.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='pods', full_name='debug_v2.App.pods', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='timeout', full_name='debug_v2.App.timeout', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='pipeline', full_name='debug_v2.App.pipeline', index=3,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1166,
+  serialized_end=1296,
+)
+
+
+_SYSTEM = _descriptor.Descriptor(
+  name='System',
+  full_name='debug_v2.System',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='helm', full_name='debug_v2.System.helm', index=0,
+      number=1, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='database', full_name='debug_v2.System.database', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='debug_v2.System.version', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='describes', full_name='debug_v2.System.describes', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='logs', full_name='debug_v2.System.logs', index=4,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='loki_logs', full_name='debug_v2.System.loki_logs', index=5,
+      number=6, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='binaries', full_name='debug_v2.System.binaries', index=6,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='profiles', full_name='debug_v2.System.profiles', index=7,
+      number=8, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1299,
+  serialized_end=1519,
+)
+
+
+_DUMPV2REQUEST = _descriptor.Descriptor(
+  name='DumpV2Request',
+  full_name='debug_v2.DumpV2Request',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='system', full_name='debug_v2.DumpV2Request.system', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='pipelines', full_name='debug_v2.DumpV2Request.pipelines', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='input_repos', full_name='debug_v2.DumpV2Request.input_repos', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='timeout', full_name='debug_v2.DumpV2Request.timeout', index=3,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1522,
+  serialized_end=1675,
+)
+
+
+_DUMPCONTENT = _descriptor.Descriptor(
+  name='DumpContent',
+  full_name='debug_v2.DumpContent',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='content', full_name='debug_v2.DumpContent.content', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1677,
+  serialized_end=1707,
+)
+
+
+_DUMPPROGRESS = _descriptor.Descriptor(
+  name='DumpProgress',
+  full_name='debug_v2.DumpProgress',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='task', full_name='debug_v2.DumpProgress.task', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='total', full_name='debug_v2.DumpProgress.total', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='progress', full_name='debug_v2.DumpProgress.progress', index=2,
+      number=3, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1709,
+  serialized_end=1770,
+)
+
+
+_DUMPCHUNK = _descriptor.Descriptor(
+  name='DumpChunk',
+  full_name='debug_v2.DumpChunk',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='content', full_name='debug_v2.DumpChunk.content', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='progress', full_name='debug_v2.DumpChunk.progress', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='chunk', full_name='debug_v2.DumpChunk.chunk',
+      index=0, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+  ],
+  serialized_start=1772,
+  serialized_end=1878,
+)
+
 _PROFILEREQUEST.fields_by_name['profile'].message_type = _PROFILE
 _PROFILEREQUEST.fields_by_name['filter'].message_type = _FILTER
 _PROFILE.fields_by_name['duration'].message_type = google_dot_protobuf_dot_duration__pb2._DURATION
@@ -441,6 +899,26 @@ _SETLOGLEVELREQUEST.fields_by_name['pachyderm'].containing_oneof = _SETLOGLEVELR
 _SETLOGLEVELREQUEST.oneofs_by_name['level'].fields.append(
   _SETLOGLEVELREQUEST.fields_by_name['grpc'])
 _SETLOGLEVELREQUEST.fields_by_name['grpc'].containing_oneof = _SETLOGLEVELREQUEST.oneofs_by_name['level']
+_GETDUMPV2TEMPLATERESPONSE.fields_by_name['request'].message_type = _DUMPV2REQUEST
+_APP.fields_by_name['pods'].message_type = _POD
+_APP.fields_by_name['timeout'].message_type = google_dot_protobuf_dot_duration__pb2._DURATION
+_APP.fields_by_name['pipeline'].message_type = _PIPELINE
+_SYSTEM.fields_by_name['describes'].message_type = _APP
+_SYSTEM.fields_by_name['logs'].message_type = _APP
+_SYSTEM.fields_by_name['loki_logs'].message_type = _APP
+_SYSTEM.fields_by_name['binaries'].message_type = _APP
+_SYSTEM.fields_by_name['profiles'].message_type = _APP
+_DUMPV2REQUEST.fields_by_name['system'].message_type = _SYSTEM
+_DUMPV2REQUEST.fields_by_name['pipelines'].message_type = _PIPELINE
+_DUMPV2REQUEST.fields_by_name['timeout'].message_type = google_dot_protobuf_dot_duration__pb2._DURATION
+_DUMPCHUNK.fields_by_name['content'].message_type = _DUMPCONTENT
+_DUMPCHUNK.fields_by_name['progress'].message_type = _DUMPPROGRESS
+_DUMPCHUNK.oneofs_by_name['chunk'].fields.append(
+  _DUMPCHUNK.fields_by_name['content'])
+_DUMPCHUNK.fields_by_name['content'].containing_oneof = _DUMPCHUNK.oneofs_by_name['chunk']
+_DUMPCHUNK.oneofs_by_name['chunk'].fields.append(
+  _DUMPCHUNK.fields_by_name['progress'])
+_DUMPCHUNK.fields_by_name['progress'].containing_oneof = _DUMPCHUNK.oneofs_by_name['chunk']
 DESCRIPTOR.message_types_by_name['ProfileRequest'] = _PROFILEREQUEST
 DESCRIPTOR.message_types_by_name['Profile'] = _PROFILE
 DESCRIPTOR.message_types_by_name['Filter'] = _FILTER
@@ -449,6 +927,16 @@ DESCRIPTOR.message_types_by_name['BinaryRequest'] = _BINARYREQUEST
 DESCRIPTOR.message_types_by_name['DumpRequest'] = _DUMPREQUEST
 DESCRIPTOR.message_types_by_name['SetLogLevelRequest'] = _SETLOGLEVELREQUEST
 DESCRIPTOR.message_types_by_name['SetLogLevelResponse'] = _SETLOGLEVELRESPONSE
+DESCRIPTOR.message_types_by_name['GetDumpV2TemplateRequest'] = _GETDUMPV2TEMPLATEREQUEST
+DESCRIPTOR.message_types_by_name['GetDumpV2TemplateResponse'] = _GETDUMPV2TEMPLATERESPONSE
+DESCRIPTOR.message_types_by_name['Pipeline'] = _PIPELINE
+DESCRIPTOR.message_types_by_name['Pod'] = _POD
+DESCRIPTOR.message_types_by_name['App'] = _APP
+DESCRIPTOR.message_types_by_name['System'] = _SYSTEM
+DESCRIPTOR.message_types_by_name['DumpV2Request'] = _DUMPV2REQUEST
+DESCRIPTOR.message_types_by_name['DumpContent'] = _DUMPCONTENT
+DESCRIPTOR.message_types_by_name['DumpProgress'] = _DUMPPROGRESS
+DESCRIPTOR.message_types_by_name['DumpChunk'] = _DUMPCHUNK
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 ProfileRequest = _reflection.GeneratedProtocolMessageType('ProfileRequest', (_message.Message,), {
@@ -507,6 +995,76 @@ SetLogLevelResponse = _reflection.GeneratedProtocolMessageType('SetLogLevelRespo
   })
 _sym_db.RegisterMessage(SetLogLevelResponse)
 
+GetDumpV2TemplateRequest = _reflection.GeneratedProtocolMessageType('GetDumpV2TemplateRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETDUMPV2TEMPLATEREQUEST,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.GetDumpV2TemplateRequest)
+  })
+_sym_db.RegisterMessage(GetDumpV2TemplateRequest)
+
+GetDumpV2TemplateResponse = _reflection.GeneratedProtocolMessageType('GetDumpV2TemplateResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETDUMPV2TEMPLATERESPONSE,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.GetDumpV2TemplateResponse)
+  })
+_sym_db.RegisterMessage(GetDumpV2TemplateResponse)
+
+Pipeline = _reflection.GeneratedProtocolMessageType('Pipeline', (_message.Message,), {
+  'DESCRIPTOR' : _PIPELINE,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.Pipeline)
+  })
+_sym_db.RegisterMessage(Pipeline)
+
+Pod = _reflection.GeneratedProtocolMessageType('Pod', (_message.Message,), {
+  'DESCRIPTOR' : _POD,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.Pod)
+  })
+_sym_db.RegisterMessage(Pod)
+
+App = _reflection.GeneratedProtocolMessageType('App', (_message.Message,), {
+  'DESCRIPTOR' : _APP,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.App)
+  })
+_sym_db.RegisterMessage(App)
+
+System = _reflection.GeneratedProtocolMessageType('System', (_message.Message,), {
+  'DESCRIPTOR' : _SYSTEM,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.System)
+  })
+_sym_db.RegisterMessage(System)
+
+DumpV2Request = _reflection.GeneratedProtocolMessageType('DumpV2Request', (_message.Message,), {
+  'DESCRIPTOR' : _DUMPV2REQUEST,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.DumpV2Request)
+  })
+_sym_db.RegisterMessage(DumpV2Request)
+
+DumpContent = _reflection.GeneratedProtocolMessageType('DumpContent', (_message.Message,), {
+  'DESCRIPTOR' : _DUMPCONTENT,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.DumpContent)
+  })
+_sym_db.RegisterMessage(DumpContent)
+
+DumpProgress = _reflection.GeneratedProtocolMessageType('DumpProgress', (_message.Message,), {
+  'DESCRIPTOR' : _DUMPPROGRESS,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.DumpProgress)
+  })
+_sym_db.RegisterMessage(DumpProgress)
+
+DumpChunk = _reflection.GeneratedProtocolMessageType('DumpChunk', (_message.Message,), {
+  'DESCRIPTOR' : _DUMPCHUNK,
+  '__module__' : 'python_pachyderm.proto.v2.debug.debug_pb2'
+  # @@protoc_insertion_point(class_scope:debug_v2.DumpChunk)
+  })
+_sym_db.RegisterMessage(DumpChunk)
+
 
 DESCRIPTOR._options = None
 
@@ -517,8 +1075,8 @@ _DEBUG = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=954,
-  serialized_end=1241,
+  serialized_start=1881,
+  serialized_end=2324,
   methods=[
   _descriptor.MethodDescriptor(
     name='Profile',
@@ -557,6 +1115,26 @@ _DEBUG = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_SETLOGLEVELREQUEST,
     output_type=_SETLOGLEVELRESPONSE,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='GetDumpV2Template',
+    full_name='debug_v2.Debug.GetDumpV2Template',
+    index=4,
+    containing_service=None,
+    input_type=_GETDUMPV2TEMPLATEREQUEST,
+    output_type=_GETDUMPV2TEMPLATERESPONSE,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='DumpV2',
+    full_name='debug_v2.Debug.DumpV2',
+    index=5,
+    containing_service=None,
+    input_type=_DUMPV2REQUEST,
+    output_type=_DUMPCHUNK,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/src/python_pachyderm/proto/v2/debug/debug_pb2_grpc.py
+++ b/src/python_pachyderm/proto/v2/debug/debug_pb2_grpc.py
@@ -35,6 +35,16 @@ class DebugStub(object):
                 request_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelRequest.SerializeToString,
                 response_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelResponse.FromString,
                 )
+        self.GetDumpV2Template = channel.unary_unary(
+                '/debug_v2.Debug/GetDumpV2Template',
+                request_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateRequest.SerializeToString,
+                response_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateResponse.FromString,
+                )
+        self.DumpV2 = channel.unary_stream(
+                '/debug_v2.Debug/DumpV2',
+                request_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpV2Request.SerializeToString,
+                response_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpChunk.FromString,
+                )
 
 
 class DebugServicer(object):
@@ -64,6 +74,18 @@ class DebugServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetDumpV2Template(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def DumpV2(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DebugServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -86,6 +108,16 @@ def add_DebugServicer_to_server(servicer, server):
                     servicer.SetLogLevel,
                     request_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelRequest.FromString,
                     response_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelResponse.SerializeToString,
+            ),
+            'GetDumpV2Template': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetDumpV2Template,
+                    request_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateRequest.FromString,
+                    response_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateResponse.SerializeToString,
+            ),
+            'DumpV2': grpc.unary_stream_rpc_method_handler(
+                    servicer.DumpV2,
+                    request_deserializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpV2Request.FromString,
+                    response_serializer=python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpChunk.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -162,5 +194,39 @@ class Debug(object):
         return grpc.experimental.unary_unary(request, target, '/debug_v2.Debug/SetLogLevel',
             python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelRequest.SerializeToString,
             python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.SetLogLevelResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def GetDumpV2Template(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/debug_v2.Debug/GetDumpV2Template',
+            python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateRequest.SerializeToString,
+            python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.GetDumpV2TemplateResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def DumpV2(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(request, target, '/debug_v2.Debug/DumpV2',
+            python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpV2Request.SerializeToString,
+            python__pachyderm_dot_proto_dot_v2_dot_debug_dot_debug__pb2.DumpChunk.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/src/python_pachyderm/proto/v2/pfs/pfs_pb2.py
+++ b/src/python_pachyderm/proto/v2/pfs/pfs_pb2.py
@@ -27,7 +27,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z)github.com/pachyderm/pachyderm/v2/src/pfs',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\'python_pachyderm/proto/v2/pfs/pfs.proto\x12\x06pfs_v2\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19google/protobuf/any.proto\x1a)python_pachyderm/proto/v2/auth/auth.proto\x1a)python_pachyderm/proto/v2/task/task.proto\"D\n\x04Repo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12 \n\x07project\x18\x03 \x01(\x0b\x32\x0f.pfs_v2.Project\"2\n\x06\x42ranch\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0c\n\x04name\x18\x02 \x01(\t\"C\n\x04\x46ile\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x03 \x01(\t\"\x99\x02\n\x08RepoInfo\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12+\n\x07\x63reated\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1e\n\x16size_bytes_upper_bound\x18\x03 \x01(\x03\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12 \n\x08\x62ranches\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12#\n\tauth_info\x18\x06 \x01(\x0b\x32\x10.pfs_v2.AuthInfo\x12)\n\x07\x64\x65tails\x18\x07 \x01(\x0b\x32\x18.pfs_v2.RepoInfo.Details\x1a\x1d\n\x07\x44\x65tails\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\"C\n\x08\x41uthInfo\x12(\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x13.auth_v2.Permission\x12\r\n\x05roles\x18\x02 \x03(\t\"\xdf\x01\n\nBranchInfo\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x1c\n\x04head\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\nprovenance\x18\x03 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12\"\n\nsubvenance\x18\x04 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12)\n\x11\x64irect_provenance\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12 \n\x07trigger\x18\x06 \x01(\x0b\x32\x0f.pfs_v2.Trigger\"X\n\x07Trigger\x12\x0e\n\x06\x62ranch\x18\x01 \x01(\t\x12\x0b\n\x03\x61ll\x18\x02 \x01(\x08\x12\x11\n\tcron_spec\x18\x03 \x01(\t\x12\x0c\n\x04size\x18\x04 \x01(\t\x12\x0f\n\x07\x63ommits\x18\x05 \x01(\x03\"0\n\x0c\x43ommitOrigin\x12 \n\x04kind\x18\x01 \x01(\x0e\x32\x12.pfs_v2.OriginKind\"P\n\x06\x43ommit\x12\x1a\n\x04repo\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\n\n\x02id\x18\x02 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\"\xd4\x04\n\nCommitInfo\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12$\n\x06origin\x18\x02 \x01(\x0b\x32\x14.pfs_v2.CommitOrigin\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12%\n\rparent_commit\x18\x04 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12%\n\rchild_commits\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12+\n\x07started\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\tfinishing\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x66inished\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12)\n\x11\x64irect_provenance\x18\r \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\r\n\x05\x65rror\x18\n \x01(\t\x12\x1e\n\x16size_bytes_upper_bound\x18\x0b \x01(\x03\x12+\n\x07\x64\x65tails\x18\x0c \x01(\x0b\x32\x1a.pfs_v2.CommitInfo.Details\x1a\x85\x01\n\x07\x44\x65tails\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\x12\x32\n\x0f\x63ompacting_time\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x32\n\x0fvalidating_time\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationJ\x04\x08\t\x10\n\"\x17\n\tCommitSet\x12\n\n\x02id\x18\x01 \x01(\t\"[\n\rCommitSetInfo\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12#\n\x07\x63ommits\x18\x02 \x03(\x0b\x32\x12.pfs_v2.CommitInfo\"\x9c\x01\n\x08\x46ileInfo\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12#\n\tfile_type\x18\x02 \x01(\x0e\x32\x10.pfs_v2.FileType\x12-\n\tcommitted\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\nsize_bytes\x18\x04 \x01(\x03\x12\x0c\n\x04hash\x18\x05 \x01(\x0c\"\x17\n\x07Project\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x99\x01\n\x0bProjectInfo\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12#\n\tauth_info\x18\x03 \x01(\x0b\x32\x10.pfs_v2.AuthInfo\x12.\n\ncreated_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"T\n\x11\x43reateRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06update\x18\x03 \x01(\x08\"0\n\x12InspectRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\"B\n\x0fListRepoRequest\x12\x0c\n\x04type\x18\x01 \x01(\t\x12!\n\x08projects\x18\x02 \x03(\x0b\x32\x0f.pfs_v2.Project\">\n\x11\x44\x65leteRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"S\n\x12\x44\x65leteReposRequest\x12!\n\x08projects\x18\x01 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"2\n\x13\x44\x65leteReposResponse\x12\x1b\n\x05repos\x18\x01 \x03(\x0b\x32\x0c.pfs_v2.Repo\"i\n\x12StartCommitRequest\x12\x1e\n\x06parent\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Branch\"h\n\x13\x46inishCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\r\n\x05\x65rror\x18\x03 \x01(\t\x12\r\n\x05\x66orce\x18\x04 \x01(\x08\"Y\n\x14InspectCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12!\n\x04wait\x18\x02 \x01(\x0e\x32\x13.pfs_v2.CommitState\"\xf2\x01\n\x11ListCommitRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x1c\n\x04\x66rom\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x1a\n\x02to\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x06 \x01(\x08\x12\'\n\x0borigin_kind\x18\x07 \x01(\x0e\x32\x12.pfs_v2.OriginKind\x12\x30\n\x0cstarted_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"N\n\x17InspectCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12\x0c\n\x04wait\x18\x02 \x01(\x08\"8\n\x14ListCommitSetRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\"?\n\x16SquashCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\"=\n\x14\x44ropCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\"\xbc\x01\n\x16SubscribeCommitRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0e\n\x06\x62ranch\x18\x02 \x01(\t\x12\x1c\n\x04\x66rom\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\x05state\x18\x04 \x01(\x0e\x32\x13.pfs_v2.CommitState\x12\x0b\n\x03\x61ll\x18\x05 \x01(\x08\x12\'\n\x0borigin_kind\x18\x06 \x01(\x0e\x32\x12.pfs_v2.OriginKind\"4\n\x12\x43learCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\"\xb1\x01\n\x13\x43reateBranchRequest\x12\x1c\n\x04head\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\"\n\nprovenance\x18\x03 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12 \n\x07trigger\x18\x04 \x01(\x0b\x32\x0f.pfs_v2.Trigger\x12\x16\n\x0enew_commit_set\x18\x05 \x01(\x08\"U\n\x12\x46indCommitsRequest\x12\x1d\n\x05start\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\r\n\x05limit\x18\x03 \x01(\r\"\x91\x01\n\x13\x46indCommitsResponse\x12&\n\x0c\x66ound_commit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12.\n\x14last_searched_commit\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12\x18\n\x10\x63ommits_searched\x18\x03 \x01(\rB\x08\n\x06result\"6\n\x14InspectBranchRequest\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\"@\n\x11ListBranchRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0f\n\x07reverse\x18\x02 \x01(\x08\"D\n\x13\x44\x65leteBranchRequest\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"]\n\x14\x43reateProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06update\x18\x03 \x01(\x08\"9\n\x15InspectProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\"\x14\n\x12ListProjectRequest\"G\n\x14\x44\x65leteProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"\xc8\x01\n\x07\x41\x64\x64\x46ile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\x12*\n\x03raw\x18\x03 \x01(\x0b\x32\x1b.google.protobuf.BytesValueH\x00\x12(\n\x03url\x18\x04 \x01(\x0b\x32\x19.pfs_v2.AddFile.URLSourceH\x00\x1a@\n\tURLSource\x12\x0b\n\x03URL\x18\x01 \x01(\t\x12\x11\n\trecursive\x18\x02 \x01(\x08\x12\x13\n\x0b\x63oncurrency\x18\x03 \x01(\rB\x08\n\x06source\")\n\nDeleteFile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\"Q\n\x08\x43opyFile\x12\x0b\n\x03\x64st\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\x12\x19\n\x03src\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06\x61ppend\x18\x04 \x01(\x08\"\xb8\x01\n\x11ModifyFileRequest\x12$\n\nset_commit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12#\n\x08\x61\x64\x64_file\x18\x02 \x01(\x0b\x32\x0f.pfs_v2.AddFileH\x00\x12)\n\x0b\x64\x65lete_file\x18\x03 \x01(\x0b\x32\x12.pfs_v2.DeleteFileH\x00\x12%\n\tcopy_file\x18\x04 \x01(\x0b\x32\x10.pfs_v2.CopyFileH\x00\x42\x06\n\x04\x62ody\"p\n\x0eGetFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0b\n\x03URL\x18\x02 \x01(\t\x12\x0e\n\x06offset\x18\x03 \x01(\x03\x12%\n\npath_range\x18\x04 \x01(\x0b\x32\x11.pfs_v2.PathRange\"0\n\x12InspectFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\"|\n\x0fListFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12&\n\x10paginationMarker\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08J\x04\x08\x02\x10\x03\"v\n\x0fWalkFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12&\n\x10paginationMarker\x18\x02 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06number\x18\x03 \x01(\x03\x12\x0f\n\x07reverse\x18\x04 \x01(\x08\"i\n\x0fGlobFileRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07pattern\x18\x02 \x01(\t\x12%\n\npath_range\x18\x03 \x01(\x0b\x32\x11.pfs_v2.PathRange\"b\n\x0f\x44iffFileRequest\x12\x1e\n\x08new_file\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x1e\n\x08old_file\x18\x02 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0f\n\x07shallow\x18\x03 \x01(\x08\"Z\n\x10\x44iffFileResponse\x12\"\n\x08new_file\x18\x01 \x01(\x0b\x32\x10.pfs_v2.FileInfo\x12\"\n\x08old_file\x18\x02 \x01(\x0b\x32\x10.pfs_v2.FileInfo\"i\n\x0b\x46sckRequest\x12\x0b\n\x03\x66ix\x18\x01 \x01(\x08\x12\'\n\rzombie_target\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12\x14\n\nzombie_all\x18\x03 \x01(\x08H\x00\x42\x0e\n\x0czombie_check\"*\n\x0c\x46sckResponse\x12\x0b\n\x03\x66ix\x18\x01 \x01(\t\x12\r\n\x05\x65rror\x18\x02 \x01(\t\",\n\x15\x43reateFileSetResponse\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\"3\n\x11GetFileSetRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\"H\n\x11\x41\x64\x64\x46ileSetRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x66ile_set_id\x18\x02 \x01(\t\"?\n\x13RenewFileSetRequest\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\x12\x13\n\x0bttl_seconds\x18\x02 \x01(\x03\"S\n\x15\x43omposeFileSetRequest\x12\x14\n\x0c\x66ile_set_ids\x18\x01 \x03(\t\x12\x13\n\x0bttl_seconds\x18\x02 \x01(\x03\x12\x0f\n\x07\x63ompact\x18\x03 \x01(\x08\"*\n\x13ShardFileSetRequest\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\")\n\tPathRange\x12\r\n\x05lower\x18\x01 \x01(\t\x12\r\n\x05upper\x18\x02 \x01(\t\"9\n\x14ShardFileSetResponse\x12!\n\x06shards\x18\x01 \x03(\x0b\x32\x11.pfs_v2.PathRange\"V\n\x13\x43heckStorageRequest\x12\x17\n\x0fread_chunk_data\x18\x01 \x01(\x08\x12\x13\n\x0b\x63hunk_begin\x18\x02 \x01(\x0c\x12\x11\n\tchunk_end\x18\x03 \x01(\x0c\"2\n\x14\x43heckStorageResponse\x12\x1a\n\x12\x63hunk_object_count\x18\x01 \x01(\x03\"f\n\x0fPutCacheRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x14\n\x0c\x66ile_set_ids\x18\x03 \x03(\t\x12\x0b\n\x03tag\x18\x04 \x01(\t\"\x1e\n\x0fGetCacheRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\"7\n\x10GetCacheResponse\x12#\n\x05value\x18\x01 \x01(\x0b\x32\x14.google.protobuf.Any\"\'\n\x11\x43learCacheRequest\x12\x12\n\ntag_prefix\x18\x01 \x01(\t\"\x15\n\x13\x41\x63tivateAuthRequest\"\x16\n\x14\x41\x63tivateAuthResponse\"b\n\x12RunLoadTestRequest\x12\x0c\n\x04spec\x18\x01 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\x10\n\x08state_id\x18\x04 \x01(\t\"\x9f\x01\n\x13RunLoadTestResponse\x12\x0c\n\x04spec\x18\x01 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\r\n\x05\x65rror\x18\x04 \x01(\t\x12+\n\x08\x64uration\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x10\n\x08state_id\x18\x06 \x01(\t\"\"\n\x13ObjectStorageEgress\x12\x0b\n\x03url\x18\x01 \x01(\t\"\xc0\x02\n\x11SQLDatabaseEgress\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x39\n\x0b\x66ile_format\x18\x02 \x01(\x0b\x32$.pfs_v2.SQLDatabaseEgress.FileFormat\x12\x30\n\x06secret\x18\x03 \x01(\x0b\x32 .pfs_v2.SQLDatabaseEgress.Secret\x1a\x8b\x01\n\nFileFormat\x12\x37\n\x04type\x18\x01 \x01(\x0e\x32).pfs_v2.SQLDatabaseEgress.FileFormat.Type\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\"3\n\x04Type\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43SV\x10\x01\x12\x08\n\x04JSON\x10\x02\x12\x0b\n\x07PARQUET\x10\x03\x1a#\n\x06Secret\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03key\x18\x02 \x01(\t\"\xa3\x01\n\rEgressRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x35\n\x0eobject_storage\x18\x02 \x01(\x0b\x32\x1b.pfs_v2.ObjectStorageEgressH\x00\x12\x31\n\x0csql_database\x18\x03 \x01(\x0b\x32\x19.pfs_v2.SQLDatabaseEgressH\x00\x42\x08\n\x06target\"\xeb\x02\n\x0e\x45gressResponse\x12\x44\n\x0eobject_storage\x18\x01 \x01(\x0b\x32*.pfs_v2.EgressResponse.ObjectStorageResultH\x00\x12@\n\x0csql_database\x18\x02 \x01(\x0b\x32(.pfs_v2.EgressResponse.SQLDatabaseResultH\x00\x1a,\n\x13ObjectStorageResult\x12\x15\n\rbytes_written\x18\x01 \x01(\x03\x1a\x98\x01\n\x11SQLDatabaseResult\x12O\n\x0crows_written\x18\x01 \x03(\x0b\x32\x39.pfs_v2.EgressResponse.SQLDatabaseResult.RowsWrittenEntry\x1a\x32\n\x10RowsWrittenEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x42\x08\n\x06result*C\n\nOriginKind\x12\x17\n\x13ORIGIN_KIND_UNKNOWN\x10\x00\x12\x08\n\x04USER\x10\x01\x12\x08\n\x04\x41UTO\x10\x02\x12\x08\n\x04\x46SCK\x10\x03*+\n\x08\x46ileType\x12\x0c\n\x08RESERVED\x10\x00\x12\x08\n\x04\x46ILE\x10\x01\x12\x07\n\x03\x44IR\x10\x02*\\\n\x0b\x43ommitState\x12\x18\n\x14\x43OMMIT_STATE_UNKNOWN\x10\x00\x12\x0b\n\x07STARTED\x10\x01\x12\t\n\x05READY\x10\x02\x12\r\n\tFINISHING\x10\x03\x12\x0c\n\x08\x46INISHED\x10\x04*;\n\tDelimiter\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04JSON\x10\x01\x12\x08\n\x04LINE\x10\x02\x12\x07\n\x03SQL\x10\x03\x12\x07\n\x03\x43SV\x10\x04\x32\xbb\x1a\n\x03\x41PI\x12\x41\n\nCreateRepo\x12\x19.pfs_v2.CreateRepoRequest\x1a\x16.google.protobuf.Empty\"\x00\x12=\n\x0bInspectRepo\x12\x1a.pfs_v2.InspectRepoRequest\x1a\x10.pfs_v2.RepoInfo\"\x00\x12\x39\n\x08ListRepo\x12\x17.pfs_v2.ListRepoRequest\x1a\x10.pfs_v2.RepoInfo\"\x00\x30\x01\x12\x41\n\nDeleteRepo\x12\x19.pfs_v2.DeleteRepoRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0b\x44\x65leteRepos\x12\x1a.pfs_v2.DeleteReposRequest\x1a\x1b.pfs_v2.DeleteReposResponse\"\x00\x12;\n\x0bStartCommit\x12\x1a.pfs_v2.StartCommitRequest\x1a\x0e.pfs_v2.Commit\"\x00\x12\x45\n\x0c\x46inishCommit\x12\x1b.pfs_v2.FinishCommitRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\x0b\x43learCommit\x12\x1a.pfs_v2.ClearCommitRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\rInspectCommit\x12\x1c.pfs_v2.InspectCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x12?\n\nListCommit\x12\x19.pfs_v2.ListCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12I\n\x0fSubscribeCommit\x12\x1e.pfs_v2.SubscribeCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12K\n\x10InspectCommitSet\x12\x1f.pfs_v2.InspectCommitSetRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12H\n\rListCommitSet\x12\x1c.pfs_v2.ListCommitSetRequest\x1a\x15.pfs_v2.CommitSetInfo\"\x00\x30\x01\x12K\n\x0fSquashCommitSet\x12\x1e.pfs_v2.SquashCommitSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12G\n\rDropCommitSet\x12\x1c.pfs_v2.DropCommitSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12J\n\x0b\x46indCommits\x12\x1a.pfs_v2.FindCommitsRequest\x1a\x1b.pfs_v2.FindCommitsResponse\"\x00\x30\x01\x12\x45\n\x0c\x43reateBranch\x12\x1b.pfs_v2.CreateBranchRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\rInspectBranch\x12\x1c.pfs_v2.InspectBranchRequest\x1a\x12.pfs_v2.BranchInfo\"\x00\x12?\n\nListBranch\x12\x19.pfs_v2.ListBranchRequest\x1a\x12.pfs_v2.BranchInfo\"\x00\x30\x01\x12\x45\n\x0c\x44\x65leteBranch\x12\x1b.pfs_v2.DeleteBranchRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\nModifyFile\x12\x19.pfs_v2.ModifyFileRequest\x1a\x16.google.protobuf.Empty\"\x00(\x01\x12\x42\n\x07GetFile\x12\x16.pfs_v2.GetFileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12\x45\n\nGetFileTAR\x12\x16.pfs_v2.GetFileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12=\n\x0bInspectFile\x12\x1a.pfs_v2.InspectFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x12\x39\n\x08ListFile\x12\x17.pfs_v2.ListFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x39\n\x08WalkFile\x12\x17.pfs_v2.WalkFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x39\n\x08GlobFile\x12\x17.pfs_v2.GlobFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x41\n\x08\x44iffFile\x12\x17.pfs_v2.DiffFileRequest\x1a\x18.pfs_v2.DiffFileResponse\"\x00\x30\x01\x12K\n\x0c\x41\x63tivateAuth\x12\x1b.pfs_v2.ActivateAuthRequest\x1a\x1c.pfs_v2.ActivateAuthResponse\"\x00\x12=\n\tDeleteAll\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12\x35\n\x04\x46sck\x12\x13.pfs_v2.FsckRequest\x1a\x14.pfs_v2.FsckResponse\"\x00\x30\x01\x12M\n\rCreateFileSet\x12\x19.pfs_v2.ModifyFileRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00(\x01\x12H\n\nGetFileSet\x12\x19.pfs_v2.GetFileSetRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00\x12\x41\n\nAddFileSet\x12\x19.pfs_v2.AddFileSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0cRenewFileSet\x12\x1b.pfs_v2.RenewFileSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12P\n\x0e\x43omposeFileSet\x12\x1d.pfs_v2.ComposeFileSetRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00\x12K\n\x0cShardFileSet\x12\x1b.pfs_v2.ShardFileSetRequest\x1a\x1c.pfs_v2.ShardFileSetResponse\"\x00\x12K\n\x0c\x43heckStorage\x12\x1b.pfs_v2.CheckStorageRequest\x1a\x1c.pfs_v2.CheckStorageResponse\"\x00\x12=\n\x08PutCache\x12\x17.pfs_v2.PutCacheRequest\x1a\x16.google.protobuf.Empty\"\x00\x12?\n\x08GetCache\x12\x17.pfs_v2.GetCacheRequest\x1a\x18.pfs_v2.GetCacheResponse\"\x00\x12\x41\n\nClearCache\x12\x19.pfs_v2.ClearCacheRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0bRunLoadTest\x12\x1a.pfs_v2.RunLoadTestRequest\x1a\x1b.pfs_v2.RunLoadTestResponse\"\x00\x12K\n\x12RunLoadTestDefault\x12\x16.google.protobuf.Empty\x1a\x1b.pfs_v2.RunLoadTestResponse\"\x00\x12;\n\x08ListTask\x12\x18.taskapi.ListTaskRequest\x1a\x11.taskapi.TaskInfo\"\x00\x30\x01\x12\x39\n\x06\x45gress\x12\x15.pfs_v2.EgressRequest\x1a\x16.pfs_v2.EgressResponse\"\x00\x12G\n\rCreateProject\x12\x1c.pfs_v2.CreateProjectRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x46\n\x0eInspectProject\x12\x1d.pfs_v2.InspectProjectRequest\x1a\x13.pfs_v2.ProjectInfo\"\x00\x12\x42\n\x0bListProject\x12\x1a.pfs_v2.ListProjectRequest\x1a\x13.pfs_v2.ProjectInfo\"\x00\x30\x01\x12G\n\rDeleteProject\x12\x1c.pfs_v2.DeleteProjectRequest\x1a\x16.google.protobuf.Empty\"\x00\x42+Z)github.com/pachyderm/pachyderm/v2/src/pfsb\x06proto3'
+  serialized_pb=b'\n\'python_pachyderm/proto/v2/pfs/pfs.proto\x12\x06pfs_v2\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19google/protobuf/any.proto\x1a)python_pachyderm/proto/v2/auth/auth.proto\x1a)python_pachyderm/proto/v2/task/task.proto\"D\n\x04Repo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12 \n\x07project\x18\x03 \x01(\x0b\x32\x0f.pfs_v2.Project\"2\n\x06\x42ranch\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0c\n\x04name\x18\x02 \x01(\t\"C\n\x04\x46ile\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x03 \x01(\t\"\x99\x02\n\x08RepoInfo\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12+\n\x07\x63reated\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1e\n\x16size_bytes_upper_bound\x18\x03 \x01(\x03\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12 \n\x08\x62ranches\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12#\n\tauth_info\x18\x06 \x01(\x0b\x32\x10.pfs_v2.AuthInfo\x12)\n\x07\x64\x65tails\x18\x07 \x01(\x0b\x32\x18.pfs_v2.RepoInfo.Details\x1a\x1d\n\x07\x44\x65tails\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\"C\n\x08\x41uthInfo\x12(\n\x0bpermissions\x18\x01 \x03(\x0e\x32\x13.auth_v2.Permission\x12\r\n\x05roles\x18\x02 \x03(\t\"\xdf\x01\n\nBranchInfo\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x1c\n\x04head\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\nprovenance\x18\x03 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12\"\n\nsubvenance\x18\x04 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12)\n\x11\x64irect_provenance\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12 \n\x07trigger\x18\x06 \x01(\x0b\x32\x0f.pfs_v2.Trigger\"q\n\x07Trigger\x12\x0e\n\x06\x62ranch\x18\x01 \x01(\t\x12\x0b\n\x03\x61ll\x18\x02 \x01(\x08\x12\x17\n\x0frate_limit_spec\x18\x03 \x01(\t\x12\x0c\n\x04size\x18\x04 \x01(\t\x12\x0f\n\x07\x63ommits\x18\x05 \x01(\x03\x12\x11\n\tcron_spec\x18\x06 \x01(\t\"0\n\x0c\x43ommitOrigin\x12 \n\x04kind\x18\x01 \x01(\x0e\x32\x12.pfs_v2.OriginKind\"P\n\x06\x43ommit\x12\x1a\n\x04repo\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\n\n\x02id\x18\x02 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\"\xd4\x04\n\nCommitInfo\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12$\n\x06origin\x18\x02 \x01(\x0b\x32\x14.pfs_v2.CommitOrigin\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12%\n\rparent_commit\x18\x04 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12%\n\rchild_commits\x18\x05 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12+\n\x07started\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\tfinishing\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x66inished\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12)\n\x11\x64irect_provenance\x18\r \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\r\n\x05\x65rror\x18\n \x01(\t\x12\x1e\n\x16size_bytes_upper_bound\x18\x0b \x01(\x03\x12+\n\x07\x64\x65tails\x18\x0c \x01(\x0b\x32\x1a.pfs_v2.CommitInfo.Details\x1a\x85\x01\n\x07\x44\x65tails\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\x12\x32\n\x0f\x63ompacting_time\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x32\n\x0fvalidating_time\x18\x03 \x01(\x0b\x32\x19.google.protobuf.DurationJ\x04\x08\t\x10\n\"\x17\n\tCommitSet\x12\n\n\x02id\x18\x01 \x01(\t\"[\n\rCommitSetInfo\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12#\n\x07\x63ommits\x18\x02 \x03(\x0b\x32\x12.pfs_v2.CommitInfo\"\x9c\x01\n\x08\x46ileInfo\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12#\n\tfile_type\x18\x02 \x01(\x0e\x32\x10.pfs_v2.FileType\x12-\n\tcommitted\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\nsize_bytes\x18\x04 \x01(\x03\x12\x0c\n\x04hash\x18\x05 \x01(\x0c\"\x17\n\x07Project\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x99\x01\n\x0bProjectInfo\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12#\n\tauth_info\x18\x03 \x01(\x0b\x32\x10.pfs_v2.AuthInfo\x12.\n\ncreated_at\x18\x04 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"T\n\x11\x43reateRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06update\x18\x03 \x01(\x08\"0\n\x12InspectRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\"B\n\x0fListRepoRequest\x12\x0c\n\x04type\x18\x01 \x01(\t\x12!\n\x08projects\x18\x02 \x03(\x0b\x32\x0f.pfs_v2.Project\">\n\x11\x44\x65leteRepoRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"S\n\x12\x44\x65leteReposRequest\x12!\n\x08projects\x18\x01 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"2\n\x13\x44\x65leteReposResponse\x12\x1b\n\x05repos\x18\x01 \x03(\x0b\x32\x0c.pfs_v2.Repo\"i\n\x12StartCommitRequest\x12\x1e\n\x06parent\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Branch\"h\n\x13\x46inishCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\r\n\x05\x65rror\x18\x03 \x01(\t\x12\r\n\x05\x66orce\x18\x04 \x01(\x08\"Y\n\x14InspectCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12!\n\x04wait\x18\x02 \x01(\x0e\x32\x13.pfs_v2.CommitState\"\xf2\x01\n\x11ListCommitRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x1c\n\x04\x66rom\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x1a\n\x02to\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x06 \x01(\x08\x12\'\n\x0borigin_kind\x18\x07 \x01(\x0e\x32\x12.pfs_v2.OriginKind\x12\x30\n\x0cstarted_time\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"N\n\x17InspectCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12\x0c\n\x04wait\x18\x02 \x01(\x08\"8\n\x14ListCommitSetRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\"?\n\x16SquashCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\"=\n\x14\x44ropCommitSetRequest\x12%\n\ncommit_set\x18\x01 \x01(\x0b\x32\x11.pfs_v2.CommitSet\"\xbc\x01\n\x16SubscribeCommitRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0e\n\x06\x62ranch\x18\x02 \x01(\t\x12\x1c\n\x04\x66rom\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\x05state\x18\x04 \x01(\x0e\x32\x13.pfs_v2.CommitState\x12\x0b\n\x03\x61ll\x18\x05 \x01(\x08\x12\'\n\x0borigin_kind\x18\x06 \x01(\x0e\x32\x12.pfs_v2.OriginKind\"4\n\x12\x43learCommitRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\"\xb1\x01\n\x13\x43reateBranchRequest\x12\x1c\n\x04head\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\"\n\nprovenance\x18\x03 \x03(\x0b\x32\x0e.pfs_v2.Branch\x12 \n\x07trigger\x18\x04 \x01(\x0b\x32\x0f.pfs_v2.Trigger\x12\x16\n\x0enew_commit_set\x18\x05 \x01(\x08\"U\n\x12\x46indCommitsRequest\x12\x1d\n\x05start\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x11\n\tfile_path\x18\x02 \x01(\t\x12\r\n\x05limit\x18\x03 \x01(\r\"\x91\x01\n\x13\x46indCommitsResponse\x12&\n\x0c\x66ound_commit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12.\n\x14last_searched_commit\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12\x18\n\x10\x63ommits_searched\x18\x03 \x01(\rB\x08\n\x06result\"6\n\x14InspectBranchRequest\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\"@\n\x11ListBranchRequest\x12\x1a\n\x04repo\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.Repo\x12\x0f\n\x07reverse\x18\x02 \x01(\x08\"D\n\x13\x44\x65leteBranchRequest\x12\x1e\n\x06\x62ranch\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"]\n\x14\x43reateProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0e\n\x06update\x18\x03 \x01(\x08\"9\n\x15InspectProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\"\x14\n\x12ListProjectRequest\"G\n\x14\x44\x65leteProjectRequest\x12 \n\x07project\x18\x01 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\"\xc8\x01\n\x07\x41\x64\x64\x46ile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\x12*\n\x03raw\x18\x03 \x01(\x0b\x32\x1b.google.protobuf.BytesValueH\x00\x12(\n\x03url\x18\x04 \x01(\x0b\x32\x19.pfs_v2.AddFile.URLSourceH\x00\x1a@\n\tURLSource\x12\x0b\n\x03URL\x18\x01 \x01(\t\x12\x11\n\trecursive\x18\x02 \x01(\x08\x12\x13\n\x0b\x63oncurrency\x18\x03 \x01(\rB\x08\n\x06source\")\n\nDeleteFile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\"Q\n\x08\x43opyFile\x12\x0b\n\x03\x64st\x18\x01 \x01(\t\x12\r\n\x05\x64\x61tum\x18\x02 \x01(\t\x12\x19\n\x03src\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06\x61ppend\x18\x04 \x01(\x08\"\xb8\x01\n\x11ModifyFileRequest\x12$\n\nset_commit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12#\n\x08\x61\x64\x64_file\x18\x02 \x01(\x0b\x32\x0f.pfs_v2.AddFileH\x00\x12)\n\x0b\x64\x65lete_file\x18\x03 \x01(\x0b\x32\x12.pfs_v2.DeleteFileH\x00\x12%\n\tcopy_file\x18\x04 \x01(\x0b\x32\x10.pfs_v2.CopyFileH\x00\x42\x06\n\x04\x62ody\"p\n\x0eGetFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0b\n\x03URL\x18\x02 \x01(\t\x12\x0e\n\x06offset\x18\x03 \x01(\x03\x12%\n\npath_range\x18\x04 \x01(\x0b\x32\x11.pfs_v2.PathRange\"0\n\x12InspectFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\"|\n\x0fListFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12&\n\x10paginationMarker\x18\x03 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08J\x04\x08\x02\x10\x03\"v\n\x0fWalkFileRequest\x12\x1a\n\x04\x66ile\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12&\n\x10paginationMarker\x18\x02 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0e\n\x06number\x18\x03 \x01(\x03\x12\x0f\n\x07reverse\x18\x04 \x01(\x08\"i\n\x0fGlobFileRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07pattern\x18\x02 \x01(\t\x12%\n\npath_range\x18\x03 \x01(\x0b\x32\x11.pfs_v2.PathRange\"b\n\x0f\x44iffFileRequest\x12\x1e\n\x08new_file\x18\x01 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x1e\n\x08old_file\x18\x02 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x0f\n\x07shallow\x18\x03 \x01(\x08\"Z\n\x10\x44iffFileResponse\x12\"\n\x08new_file\x18\x01 \x01(\x0b\x32\x10.pfs_v2.FileInfo\x12\"\n\x08old_file\x18\x02 \x01(\x0b\x32\x10.pfs_v2.FileInfo\"i\n\x0b\x46sckRequest\x12\x0b\n\x03\x66ix\x18\x01 \x01(\x08\x12\'\n\rzombie_target\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.CommitH\x00\x12\x14\n\nzombie_all\x18\x03 \x01(\x08H\x00\x42\x0e\n\x0czombie_check\"*\n\x0c\x46sckResponse\x12\x0b\n\x03\x66ix\x18\x01 \x01(\t\x12\r\n\x05\x65rror\x18\x02 \x01(\t\",\n\x15\x43reateFileSetResponse\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\"3\n\x11GetFileSetRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\"H\n\x11\x41\x64\x64\x46ileSetRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x13\n\x0b\x66ile_set_id\x18\x02 \x01(\t\"?\n\x13RenewFileSetRequest\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\x12\x13\n\x0bttl_seconds\x18\x02 \x01(\x03\"S\n\x15\x43omposeFileSetRequest\x12\x14\n\x0c\x66ile_set_ids\x18\x01 \x03(\t\x12\x13\n\x0bttl_seconds\x18\x02 \x01(\x03\x12\x0f\n\x07\x63ompact\x18\x03 \x01(\x08\"*\n\x13ShardFileSetRequest\x12\x13\n\x0b\x66ile_set_id\x18\x01 \x01(\t\")\n\tPathRange\x12\r\n\x05lower\x18\x01 \x01(\t\x12\r\n\x05upper\x18\x02 \x01(\t\"9\n\x14ShardFileSetResponse\x12!\n\x06shards\x18\x01 \x03(\x0b\x32\x11.pfs_v2.PathRange\"V\n\x13\x43heckStorageRequest\x12\x17\n\x0fread_chunk_data\x18\x01 \x01(\x08\x12\x13\n\x0b\x63hunk_begin\x18\x02 \x01(\x0c\x12\x11\n\tchunk_end\x18\x03 \x01(\x0c\"2\n\x14\x43heckStorageResponse\x12\x1a\n\x12\x63hunk_object_count\x18\x01 \x01(\x03\"f\n\x0fPutCacheRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.Any\x12\x14\n\x0c\x66ile_set_ids\x18\x03 \x03(\t\x12\x0b\n\x03tag\x18\x04 \x01(\t\"\x1e\n\x0fGetCacheRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\"7\n\x10GetCacheResponse\x12#\n\x05value\x18\x01 \x01(\x0b\x32\x14.google.protobuf.Any\"\'\n\x11\x43learCacheRequest\x12\x12\n\ntag_prefix\x18\x01 \x01(\t\"\x15\n\x13\x41\x63tivateAuthRequest\"\x16\n\x14\x41\x63tivateAuthResponse\"b\n\x12RunLoadTestRequest\x12\x0c\n\x04spec\x18\x01 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\x10\n\x08state_id\x18\x04 \x01(\t\"\x9f\x01\n\x13RunLoadTestResponse\x12\x0c\n\x04spec\x18\x01 \x01(\t\x12\x1e\n\x06\x62ranch\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Branch\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\r\n\x05\x65rror\x18\x04 \x01(\t\x12+\n\x08\x64uration\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x10\n\x08state_id\x18\x06 \x01(\t\"\"\n\x13ObjectStorageEgress\x12\x0b\n\x03url\x18\x01 \x01(\t\"\xc0\x02\n\x11SQLDatabaseEgress\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x39\n\x0b\x66ile_format\x18\x02 \x01(\x0b\x32$.pfs_v2.SQLDatabaseEgress.FileFormat\x12\x30\n\x06secret\x18\x03 \x01(\x0b\x32 .pfs_v2.SQLDatabaseEgress.Secret\x1a\x8b\x01\n\nFileFormat\x12\x37\n\x04type\x18\x01 \x01(\x0e\x32).pfs_v2.SQLDatabaseEgress.FileFormat.Type\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\"3\n\x04Type\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03\x43SV\x10\x01\x12\x08\n\x04JSON\x10\x02\x12\x0b\n\x07PARQUET\x10\x03\x1a#\n\x06Secret\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03key\x18\x02 \x01(\t\"\xa3\x01\n\rEgressRequest\x12\x1e\n\x06\x63ommit\x18\x01 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x35\n\x0eobject_storage\x18\x02 \x01(\x0b\x32\x1b.pfs_v2.ObjectStorageEgressH\x00\x12\x31\n\x0csql_database\x18\x03 \x01(\x0b\x32\x19.pfs_v2.SQLDatabaseEgressH\x00\x42\x08\n\x06target\"\xeb\x02\n\x0e\x45gressResponse\x12\x44\n\x0eobject_storage\x18\x01 \x01(\x0b\x32*.pfs_v2.EgressResponse.ObjectStorageResultH\x00\x12@\n\x0csql_database\x18\x02 \x01(\x0b\x32(.pfs_v2.EgressResponse.SQLDatabaseResultH\x00\x1a,\n\x13ObjectStorageResult\x12\x15\n\rbytes_written\x18\x01 \x01(\x03\x1a\x98\x01\n\x11SQLDatabaseResult\x12O\n\x0crows_written\x18\x01 \x03(\x0b\x32\x39.pfs_v2.EgressResponse.SQLDatabaseResult.RowsWrittenEntry\x1a\x32\n\x10RowsWrittenEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\x42\x08\n\x06result*I\n\nOriginKind\x12\x17\n\x13ORIGIN_KIND_UNKNOWN\x10\x00\x12\x08\n\x04USER\x10\x01\x12\x08\n\x04\x41UTO\x10\x02\x12\x08\n\x04\x46SCK\x10\x03\"\x04\x08\x04\x10\x04*+\n\x08\x46ileType\x12\x0c\n\x08RESERVED\x10\x00\x12\x08\n\x04\x46ILE\x10\x01\x12\x07\n\x03\x44IR\x10\x02*\\\n\x0b\x43ommitState\x12\x18\n\x14\x43OMMIT_STATE_UNKNOWN\x10\x00\x12\x0b\n\x07STARTED\x10\x01\x12\t\n\x05READY\x10\x02\x12\r\n\tFINISHING\x10\x03\x12\x0c\n\x08\x46INISHED\x10\x04*;\n\tDelimiter\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04JSON\x10\x01\x12\x08\n\x04LINE\x10\x02\x12\x07\n\x03SQL\x10\x03\x12\x07\n\x03\x43SV\x10\x04\x32\xbb\x1a\n\x03\x41PI\x12\x41\n\nCreateRepo\x12\x19.pfs_v2.CreateRepoRequest\x1a\x16.google.protobuf.Empty\"\x00\x12=\n\x0bInspectRepo\x12\x1a.pfs_v2.InspectRepoRequest\x1a\x10.pfs_v2.RepoInfo\"\x00\x12\x39\n\x08ListRepo\x12\x17.pfs_v2.ListRepoRequest\x1a\x10.pfs_v2.RepoInfo\"\x00\x30\x01\x12\x41\n\nDeleteRepo\x12\x19.pfs_v2.DeleteRepoRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0b\x44\x65leteRepos\x12\x1a.pfs_v2.DeleteReposRequest\x1a\x1b.pfs_v2.DeleteReposResponse\"\x00\x12;\n\x0bStartCommit\x12\x1a.pfs_v2.StartCommitRequest\x1a\x0e.pfs_v2.Commit\"\x00\x12\x45\n\x0c\x46inishCommit\x12\x1b.pfs_v2.FinishCommitRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\x0b\x43learCommit\x12\x1a.pfs_v2.ClearCommitRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\rInspectCommit\x12\x1c.pfs_v2.InspectCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x12?\n\nListCommit\x12\x19.pfs_v2.ListCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12I\n\x0fSubscribeCommit\x12\x1e.pfs_v2.SubscribeCommitRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12K\n\x10InspectCommitSet\x12\x1f.pfs_v2.InspectCommitSetRequest\x1a\x12.pfs_v2.CommitInfo\"\x00\x30\x01\x12H\n\rListCommitSet\x12\x1c.pfs_v2.ListCommitSetRequest\x1a\x15.pfs_v2.CommitSetInfo\"\x00\x30\x01\x12K\n\x0fSquashCommitSet\x12\x1e.pfs_v2.SquashCommitSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12G\n\rDropCommitSet\x12\x1c.pfs_v2.DropCommitSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12J\n\x0b\x46indCommits\x12\x1a.pfs_v2.FindCommitsRequest\x1a\x1b.pfs_v2.FindCommitsResponse\"\x00\x30\x01\x12\x45\n\x0c\x43reateBranch\x12\x1b.pfs_v2.CreateBranchRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\rInspectBranch\x12\x1c.pfs_v2.InspectBranchRequest\x1a\x12.pfs_v2.BranchInfo\"\x00\x12?\n\nListBranch\x12\x19.pfs_v2.ListBranchRequest\x1a\x12.pfs_v2.BranchInfo\"\x00\x30\x01\x12\x45\n\x0c\x44\x65leteBranch\x12\x1b.pfs_v2.DeleteBranchRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\nModifyFile\x12\x19.pfs_v2.ModifyFileRequest\x1a\x16.google.protobuf.Empty\"\x00(\x01\x12\x42\n\x07GetFile\x12\x16.pfs_v2.GetFileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12\x45\n\nGetFileTAR\x12\x16.pfs_v2.GetFileRequest\x1a\x1b.google.protobuf.BytesValue\"\x00\x30\x01\x12=\n\x0bInspectFile\x12\x1a.pfs_v2.InspectFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x12\x39\n\x08ListFile\x12\x17.pfs_v2.ListFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x39\n\x08WalkFile\x12\x17.pfs_v2.WalkFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x39\n\x08GlobFile\x12\x17.pfs_v2.GlobFileRequest\x1a\x10.pfs_v2.FileInfo\"\x00\x30\x01\x12\x41\n\x08\x44iffFile\x12\x17.pfs_v2.DiffFileRequest\x1a\x18.pfs_v2.DiffFileResponse\"\x00\x30\x01\x12K\n\x0c\x41\x63tivateAuth\x12\x1b.pfs_v2.ActivateAuthRequest\x1a\x1c.pfs_v2.ActivateAuthResponse\"\x00\x12=\n\tDeleteAll\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12\x35\n\x04\x46sck\x12\x13.pfs_v2.FsckRequest\x1a\x14.pfs_v2.FsckResponse\"\x00\x30\x01\x12M\n\rCreateFileSet\x12\x19.pfs_v2.ModifyFileRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00(\x01\x12H\n\nGetFileSet\x12\x19.pfs_v2.GetFileSetRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00\x12\x41\n\nAddFileSet\x12\x19.pfs_v2.AddFileSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0cRenewFileSet\x12\x1b.pfs_v2.RenewFileSetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12P\n\x0e\x43omposeFileSet\x12\x1d.pfs_v2.ComposeFileSetRequest\x1a\x1d.pfs_v2.CreateFileSetResponse\"\x00\x12K\n\x0cShardFileSet\x12\x1b.pfs_v2.ShardFileSetRequest\x1a\x1c.pfs_v2.ShardFileSetResponse\"\x00\x12K\n\x0c\x43heckStorage\x12\x1b.pfs_v2.CheckStorageRequest\x1a\x1c.pfs_v2.CheckStorageResponse\"\x00\x12=\n\x08PutCache\x12\x17.pfs_v2.PutCacheRequest\x1a\x16.google.protobuf.Empty\"\x00\x12?\n\x08GetCache\x12\x17.pfs_v2.GetCacheRequest\x1a\x18.pfs_v2.GetCacheResponse\"\x00\x12\x41\n\nClearCache\x12\x19.pfs_v2.ClearCacheRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0bRunLoadTest\x12\x1a.pfs_v2.RunLoadTestRequest\x1a\x1b.pfs_v2.RunLoadTestResponse\"\x00\x12K\n\x12RunLoadTestDefault\x12\x16.google.protobuf.Empty\x1a\x1b.pfs_v2.RunLoadTestResponse\"\x00\x12;\n\x08ListTask\x12\x18.taskapi.ListTaskRequest\x1a\x11.taskapi.TaskInfo\"\x00\x30\x01\x12\x39\n\x06\x45gress\x12\x15.pfs_v2.EgressRequest\x1a\x16.pfs_v2.EgressResponse\"\x00\x12G\n\rCreateProject\x12\x1c.pfs_v2.CreateProjectRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x46\n\x0eInspectProject\x12\x1d.pfs_v2.InspectProjectRequest\x1a\x13.pfs_v2.ProjectInfo\"\x00\x12\x42\n\x0bListProject\x12\x1a.pfs_v2.ListProjectRequest\x1a\x13.pfs_v2.ProjectInfo\"\x00\x30\x01\x12G\n\rDeleteProject\x12\x1c.pfs_v2.DeleteProjectRequest\x1a\x16.google.protobuf.Empty\"\x00\x42+Z)github.com/pachyderm/pachyderm/v2/src/pfsb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,google_dot_protobuf_dot_any__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_auth_dot_auth__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_task_dot_task__pb2.DESCRIPTOR,])
 
@@ -61,8 +61,8 @@ _ORIGINKIND = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=8079,
-  serialized_end=8146,
+  serialized_start=8104,
+  serialized_end=8177,
 )
 _sym_db.RegisterEnumDescriptor(_ORIGINKIND)
 
@@ -92,8 +92,8 @@ _FILETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=8148,
-  serialized_end=8191,
+  serialized_start=8179,
+  serialized_end=8222,
 )
 _sym_db.RegisterEnumDescriptor(_FILETYPE)
 
@@ -133,8 +133,8 @@ _COMMITSTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=8193,
-  serialized_end=8285,
+  serialized_start=8224,
+  serialized_end=8316,
 )
 _sym_db.RegisterEnumDescriptor(_COMMITSTATE)
 
@@ -174,8 +174,8 @@ _DELIMITER = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=8287,
-  serialized_end=8346,
+  serialized_start=8318,
+  serialized_end=8377,
 )
 _sym_db.RegisterEnumDescriptor(_DELIMITER)
 
@@ -229,8 +229,8 @@ _SQLDATABASEEGRESS_FILEFORMAT_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=7457,
-  serialized_end=7508,
+  serialized_start=7482,
+  serialized_end=7533,
 )
 _sym_db.RegisterEnumDescriptor(_SQLDATABASEEGRESS_FILEFORMAT_TYPE)
 
@@ -600,7 +600,7 @@ _TRIGGER = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='cron_spec', full_name='pfs_v2.Trigger.cron_spec', index=2,
+      name='rate_limit_spec', full_name='pfs_v2.Trigger.rate_limit_spec', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -620,6 +620,13 @@ _TRIGGER = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='cron_spec', full_name='pfs_v2.Trigger.cron_spec', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -633,7 +640,7 @@ _TRIGGER = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1060,
-  serialized_end=1148,
+  serialized_end=1173,
 )
 
 
@@ -664,8 +671,8 @@ _COMMITORIGIN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1150,
-  serialized_end=1198,
+  serialized_start=1175,
+  serialized_end=1223,
 )
 
 
@@ -710,8 +717,8 @@ _COMMIT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1200,
-  serialized_end=1280,
+  serialized_start=1225,
+  serialized_end=1305,
 )
 
 
@@ -756,8 +763,8 @@ _COMMITINFO_DETAILS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1740,
-  serialized_end=1873,
+  serialized_start=1765,
+  serialized_end=1898,
 )
 
 _COMMITINFO = _descriptor.Descriptor(
@@ -864,8 +871,8 @@ _COMMITINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1283,
-  serialized_end=1879,
+  serialized_start=1308,
+  serialized_end=1904,
 )
 
 
@@ -896,8 +903,8 @@ _COMMITSET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1881,
-  serialized_end=1904,
+  serialized_start=1906,
+  serialized_end=1929,
 )
 
 
@@ -935,8 +942,8 @@ _COMMITSETINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1906,
-  serialized_end=1997,
+  serialized_start=1931,
+  serialized_end=2022,
 )
 
 
@@ -995,8 +1002,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2000,
-  serialized_end=2156,
+  serialized_start=2025,
+  serialized_end=2181,
 )
 
 
@@ -1027,8 +1034,8 @@ _PROJECT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2158,
-  serialized_end=2181,
+  serialized_start=2183,
+  serialized_end=2206,
 )
 
 
@@ -1080,8 +1087,8 @@ _PROJECTINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2184,
-  serialized_end=2337,
+  serialized_start=2209,
+  serialized_end=2362,
 )
 
 
@@ -1126,8 +1133,8 @@ _CREATEREPOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2339,
-  serialized_end=2423,
+  serialized_start=2364,
+  serialized_end=2448,
 )
 
 
@@ -1158,8 +1165,8 @@ _INSPECTREPOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2425,
-  serialized_end=2473,
+  serialized_start=2450,
+  serialized_end=2498,
 )
 
 
@@ -1197,8 +1204,8 @@ _LISTREPOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2475,
-  serialized_end=2541,
+  serialized_start=2500,
+  serialized_end=2566,
 )
 
 
@@ -1236,8 +1243,8 @@ _DELETEREPOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2543,
-  serialized_end=2605,
+  serialized_start=2568,
+  serialized_end=2630,
 )
 
 
@@ -1282,8 +1289,8 @@ _DELETEREPOSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2607,
-  serialized_end=2690,
+  serialized_start=2632,
+  serialized_end=2715,
 )
 
 
@@ -1314,8 +1321,8 @@ _DELETEREPOSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2692,
-  serialized_end=2742,
+  serialized_start=2717,
+  serialized_end=2767,
 )
 
 
@@ -1360,8 +1367,8 @@ _STARTCOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2744,
-  serialized_end=2849,
+  serialized_start=2769,
+  serialized_end=2874,
 )
 
 
@@ -1413,8 +1420,8 @@ _FINISHCOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2851,
-  serialized_end=2955,
+  serialized_start=2876,
+  serialized_end=2980,
 )
 
 
@@ -1452,8 +1459,8 @@ _INSPECTCOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2957,
-  serialized_end=3046,
+  serialized_start=2982,
+  serialized_end=3071,
 )
 
 
@@ -1533,8 +1540,8 @@ _LISTCOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3049,
-  serialized_end=3291,
+  serialized_start=3074,
+  serialized_end=3316,
 )
 
 
@@ -1572,8 +1579,8 @@ _INSPECTCOMMITSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3293,
-  serialized_end=3371,
+  serialized_start=3318,
+  serialized_end=3396,
 )
 
 
@@ -1604,8 +1611,8 @@ _LISTCOMMITSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3373,
-  serialized_end=3429,
+  serialized_start=3398,
+  serialized_end=3454,
 )
 
 
@@ -1636,8 +1643,8 @@ _SQUASHCOMMITSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3431,
-  serialized_end=3494,
+  serialized_start=3456,
+  serialized_end=3519,
 )
 
 
@@ -1668,8 +1675,8 @@ _DROPCOMMITSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3496,
-  serialized_end=3557,
+  serialized_start=3521,
+  serialized_end=3582,
 )
 
 
@@ -1735,8 +1742,8 @@ _SUBSCRIBECOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3560,
-  serialized_end=3748,
+  serialized_start=3585,
+  serialized_end=3773,
 )
 
 
@@ -1767,8 +1774,8 @@ _CLEARCOMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3750,
-  serialized_end=3802,
+  serialized_start=3775,
+  serialized_end=3827,
 )
 
 
@@ -1827,8 +1834,8 @@ _CREATEBRANCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3805,
-  serialized_end=3982,
+  serialized_start=3830,
+  serialized_end=4007,
 )
 
 
@@ -1873,8 +1880,8 @@ _FINDCOMMITSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3984,
-  serialized_end=4069,
+  serialized_start=4009,
+  serialized_end=4094,
 )
 
 
@@ -1924,8 +1931,8 @@ _FINDCOMMITSRESPONSE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4072,
-  serialized_end=4217,
+  serialized_start=4097,
+  serialized_end=4242,
 )
 
 
@@ -1956,8 +1963,8 @@ _INSPECTBRANCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4219,
-  serialized_end=4273,
+  serialized_start=4244,
+  serialized_end=4298,
 )
 
 
@@ -1995,8 +2002,8 @@ _LISTBRANCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4275,
-  serialized_end=4339,
+  serialized_start=4300,
+  serialized_end=4364,
 )
 
 
@@ -2034,8 +2041,8 @@ _DELETEBRANCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4341,
-  serialized_end=4409,
+  serialized_start=4366,
+  serialized_end=4434,
 )
 
 
@@ -2080,8 +2087,8 @@ _CREATEPROJECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4411,
-  serialized_end=4504,
+  serialized_start=4436,
+  serialized_end=4529,
 )
 
 
@@ -2112,8 +2119,8 @@ _INSPECTPROJECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4506,
-  serialized_end=4563,
+  serialized_start=4531,
+  serialized_end=4588,
 )
 
 
@@ -2137,8 +2144,8 @@ _LISTPROJECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4565,
-  serialized_end=4585,
+  serialized_start=4590,
+  serialized_end=4610,
 )
 
 
@@ -2176,8 +2183,8 @@ _DELETEPROJECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4587,
-  serialized_end=4658,
+  serialized_start=4612,
+  serialized_end=4683,
 )
 
 
@@ -2222,8 +2229,8 @@ _ADDFILE_URLSOURCE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4787,
-  serialized_end=4851,
+  serialized_start=4812,
+  serialized_end=4876,
 )
 
 _ADDFILE = _descriptor.Descriptor(
@@ -2279,8 +2286,8 @@ _ADDFILE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4661,
-  serialized_end=4861,
+  serialized_start=4686,
+  serialized_end=4886,
 )
 
 
@@ -2318,8 +2325,8 @@ _DELETEFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4863,
-  serialized_end=4904,
+  serialized_start=4888,
+  serialized_end=4929,
 )
 
 
@@ -2371,8 +2378,8 @@ _COPYFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4906,
-  serialized_end=4987,
+  serialized_start=4931,
+  serialized_end=5012,
 )
 
 
@@ -2429,8 +2436,8 @@ _MODIFYFILEREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=4990,
-  serialized_end=5174,
+  serialized_start=5015,
+  serialized_end=5199,
 )
 
 
@@ -2482,8 +2489,8 @@ _GETFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5176,
-  serialized_end=5288,
+  serialized_start=5201,
+  serialized_end=5313,
 )
 
 
@@ -2514,8 +2521,8 @@ _INSPECTFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5290,
-  serialized_end=5338,
+  serialized_start=5315,
+  serialized_end=5363,
 )
 
 
@@ -2567,8 +2574,8 @@ _LISTFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5340,
-  serialized_end=5464,
+  serialized_start=5365,
+  serialized_end=5489,
 )
 
 
@@ -2620,8 +2627,8 @@ _WALKFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5466,
-  serialized_end=5584,
+  serialized_start=5491,
+  serialized_end=5609,
 )
 
 
@@ -2666,8 +2673,8 @@ _GLOBFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5586,
-  serialized_end=5691,
+  serialized_start=5611,
+  serialized_end=5716,
 )
 
 
@@ -2712,8 +2719,8 @@ _DIFFFILEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5693,
-  serialized_end=5791,
+  serialized_start=5718,
+  serialized_end=5816,
 )
 
 
@@ -2751,8 +2758,8 @@ _DIFFFILERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5793,
-  serialized_end=5883,
+  serialized_start=5818,
+  serialized_end=5908,
 )
 
 
@@ -2802,8 +2809,8 @@ _FSCKREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=5885,
-  serialized_end=5990,
+  serialized_start=5910,
+  serialized_end=6015,
 )
 
 
@@ -2841,8 +2848,8 @@ _FSCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5992,
-  serialized_end=6034,
+  serialized_start=6017,
+  serialized_end=6059,
 )
 
 
@@ -2873,8 +2880,8 @@ _CREATEFILESETRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6036,
-  serialized_end=6080,
+  serialized_start=6061,
+  serialized_end=6105,
 )
 
 
@@ -2905,8 +2912,8 @@ _GETFILESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6082,
-  serialized_end=6133,
+  serialized_start=6107,
+  serialized_end=6158,
 )
 
 
@@ -2944,8 +2951,8 @@ _ADDFILESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6135,
-  serialized_end=6207,
+  serialized_start=6160,
+  serialized_end=6232,
 )
 
 
@@ -2983,8 +2990,8 @@ _RENEWFILESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6209,
-  serialized_end=6272,
+  serialized_start=6234,
+  serialized_end=6297,
 )
 
 
@@ -3029,8 +3036,8 @@ _COMPOSEFILESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6274,
-  serialized_end=6357,
+  serialized_start=6299,
+  serialized_end=6382,
 )
 
 
@@ -3061,8 +3068,8 @@ _SHARDFILESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6359,
-  serialized_end=6401,
+  serialized_start=6384,
+  serialized_end=6426,
 )
 
 
@@ -3100,8 +3107,8 @@ _PATHRANGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6403,
-  serialized_end=6444,
+  serialized_start=6428,
+  serialized_end=6469,
 )
 
 
@@ -3132,8 +3139,8 @@ _SHARDFILESETRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6446,
-  serialized_end=6503,
+  serialized_start=6471,
+  serialized_end=6528,
 )
 
 
@@ -3178,8 +3185,8 @@ _CHECKSTORAGEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6505,
-  serialized_end=6591,
+  serialized_start=6530,
+  serialized_end=6616,
 )
 
 
@@ -3210,8 +3217,8 @@ _CHECKSTORAGERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6593,
-  serialized_end=6643,
+  serialized_start=6618,
+  serialized_end=6668,
 )
 
 
@@ -3263,8 +3270,8 @@ _PUTCACHEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6645,
-  serialized_end=6747,
+  serialized_start=6670,
+  serialized_end=6772,
 )
 
 
@@ -3295,8 +3302,8 @@ _GETCACHEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6749,
-  serialized_end=6779,
+  serialized_start=6774,
+  serialized_end=6804,
 )
 
 
@@ -3327,8 +3334,8 @@ _GETCACHERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6781,
-  serialized_end=6836,
+  serialized_start=6806,
+  serialized_end=6861,
 )
 
 
@@ -3359,8 +3366,8 @@ _CLEARCACHEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6838,
-  serialized_end=6877,
+  serialized_start=6863,
+  serialized_end=6902,
 )
 
 
@@ -3384,8 +3391,8 @@ _ACTIVATEAUTHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6879,
-  serialized_end=6900,
+  serialized_start=6904,
+  serialized_end=6925,
 )
 
 
@@ -3409,8 +3416,8 @@ _ACTIVATEAUTHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6902,
-  serialized_end=6924,
+  serialized_start=6927,
+  serialized_end=6949,
 )
 
 
@@ -3462,8 +3469,8 @@ _RUNLOADTESTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6926,
-  serialized_end=7024,
+  serialized_start=6951,
+  serialized_end=7049,
 )
 
 
@@ -3529,8 +3536,8 @@ _RUNLOADTESTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7027,
-  serialized_end=7186,
+  serialized_start=7052,
+  serialized_end=7211,
 )
 
 
@@ -3561,8 +3568,8 @@ _OBJECTSTORAGEEGRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7188,
-  serialized_end=7222,
+  serialized_start=7213,
+  serialized_end=7247,
 )
 
 
@@ -3601,8 +3608,8 @@ _SQLDATABASEEGRESS_FILEFORMAT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7369,
-  serialized_end=7508,
+  serialized_start=7394,
+  serialized_end=7533,
 )
 
 _SQLDATABASEEGRESS_SECRET = _descriptor.Descriptor(
@@ -3639,8 +3646,8 @@ _SQLDATABASEEGRESS_SECRET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7510,
-  serialized_end=7545,
+  serialized_start=7535,
+  serialized_end=7570,
 )
 
 _SQLDATABASEEGRESS = _descriptor.Descriptor(
@@ -3684,8 +3691,8 @@ _SQLDATABASEEGRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7225,
-  serialized_end=7545,
+  serialized_start=7250,
+  serialized_end=7570,
 )
 
 
@@ -3735,8 +3742,8 @@ _EGRESSREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=7548,
-  serialized_end=7711,
+  serialized_start=7573,
+  serialized_end=7736,
 )
 
 
@@ -3767,8 +3774,8 @@ _EGRESSRESPONSE_OBJECTSTORAGERESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7868,
-  serialized_end=7912,
+  serialized_start=7893,
+  serialized_end=7937,
 )
 
 _EGRESSRESPONSE_SQLDATABASERESULT_ROWSWRITTENENTRY = _descriptor.Descriptor(
@@ -3805,8 +3812,8 @@ _EGRESSRESPONSE_SQLDATABASERESULT_ROWSWRITTENENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8017,
-  serialized_end=8067,
+  serialized_start=8042,
+  serialized_end=8092,
 )
 
 _EGRESSRESPONSE_SQLDATABASERESULT = _descriptor.Descriptor(
@@ -3836,8 +3843,8 @@ _EGRESSRESPONSE_SQLDATABASERESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7915,
-  serialized_end=8067,
+  serialized_start=7940,
+  serialized_end=8092,
 )
 
 _EGRESSRESPONSE = _descriptor.Descriptor(
@@ -3879,8 +3886,8 @@ _EGRESSRESPONSE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=7714,
-  serialized_end=8077,
+  serialized_start=7739,
+  serialized_end=8102,
 )
 
 _REPO.fields_by_name['project'].message_type = _PROJECT
@@ -4736,8 +4743,8 @@ _API = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=8349,
-  serialized_end=11736,
+  serialized_start=8380,
+  serialized_end=11767,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateRepo',

--- a/src/python_pachyderm/proto/v2/pps/pps_pb2.py
+++ b/src/python_pachyderm/proto/v2/pps/pps_pb2.py
@@ -26,7 +26,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'Z)github.com/pachyderm/pachyderm/v2/src/pps',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\'python_pachyderm/proto/v2/pps/pps.proto\x12\x06pps_v2\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\'python_pachyderm/proto/v2/pfs/pfs.proto\x1a)python_pachyderm/proto/v2/task/task.proto\"M\n\x0bSecretMount\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03key\x18\x02 \x01(\t\x12\x12\n\nmount_path\x18\x03 \x01(\t\x12\x0f\n\x07\x65nv_var\x18\x04 \x01(\t\"\x82\x03\n\tTransform\x12\r\n\x05image\x18\x01 \x01(\t\x12\x0b\n\x03\x63md\x18\x02 \x03(\t\x12\x0f\n\x07\x65rr_cmd\x18\x03 \x03(\t\x12\'\n\x03\x65nv\x18\x04 \x03(\x0b\x32\x1a.pps_v2.Transform.EnvEntry\x12$\n\x07secrets\x18\x05 \x03(\x0b\x32\x13.pps_v2.SecretMount\x12\x1a\n\x12image_pull_secrets\x18\x06 \x03(\t\x12\r\n\x05stdin\x18\x07 \x03(\t\x12\x11\n\terr_stdin\x18\x08 \x03(\t\x12\x1a\n\x12\x61\x63\x63\x65pt_return_code\x18\t \x03(\x03\x12\r\n\x05\x64\x65\x62ug\x18\n \x01(\x08\x12\x0c\n\x04user\x18\x0b \x01(\t\x12\x13\n\x0bworking_dir\x18\x0c \x01(\t\x12\x12\n\ndockerfile\x18\r \x01(\t\x12\x15\n\rmemory_volume\x18\x0e \x01(\x08\x12\x16\n\x0e\x64\x61tum_batching\x18\x0f \x01(\x08\x1a*\n\x08\x45nvEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x17\n\x05TFJob\x12\x0e\n\x06tf_job\x18\x01 \x01(\t\"\x89\x01\n\x06\x45gress\x12\x0b\n\x03URL\x18\x01 \x01(\t\x12\x35\n\x0eobject_storage\x18\x02 \x01(\x0b\x32\x1b.pfs_v2.ObjectStorageEgressH\x00\x12\x31\n\x0csql_database\x18\x03 \x01(\x0b\x32\x19.pfs_v2.SQLDatabaseEgressH\x00\x42\x08\n\x06target\"5\n\x03Job\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\n\n\x02id\x18\x02 \x01(\t\"\xd3\x01\n\x08Metadata\x12\x36\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32!.pps_v2.Metadata.AnnotationsEntry\x12,\n\x06labels\x18\x02 \x03(\x0b\x32\x1c.pps_v2.Metadata.LabelsEntry\x1a\x32\n\x10\x41nnotationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"Q\n\x07Service\x12\x15\n\rinternal_port\x18\x01 \x01(\x05\x12\x15\n\rexternal_port\x18\x02 \x01(\x05\x12\n\n\x02ip\x18\x03 \x01(\t\x12\x0c\n\x04type\x18\x04 \x01(\t\")\n\x05Spout\x12 \n\x07service\x18\x01 \x01(\x0b\x32\x0f.pps_v2.Service\"\x80\x02\n\x08PFSInput\x12\x0f\n\x07project\x18\x0e \x01(\t\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x11\n\trepo_type\x18\r \x01(\t\x12\x0e\n\x06\x62ranch\x18\x03 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x04 \x01(\t\x12\x0c\n\x04glob\x18\x05 \x01(\t\x12\x0f\n\x07join_on\x18\x06 \x01(\t\x12\x12\n\nouter_join\x18\x07 \x01(\x08\x12\x10\n\x08group_by\x18\x08 \x01(\t\x12\x0c\n\x04lazy\x18\t \x01(\x08\x12\x13\n\x0b\x65mpty_files\x18\n \x01(\x08\x12\n\n\x02s3\x18\x0b \x01(\x08\x12 \n\x07trigger\x18\x0c \x01(\x0b\x32\x0f.pfs_v2.Trigger\"\x94\x01\n\tCronInput\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x07 \x01(\t\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x03 \x01(\t\x12\x0c\n\x04spec\x18\x04 \x01(\t\x12\x11\n\toverwrite\x18\x05 \x01(\x08\x12)\n\x05start\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xbe\x01\n\x05Input\x12\x1d\n\x03pfs\x18\x01 \x01(\x0b\x32\x10.pps_v2.PFSInput\x12\x1b\n\x04join\x18\x02 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05group\x18\x03 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05\x63ross\x18\x04 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05union\x18\x05 \x03(\x0b\x32\r.pps_v2.Input\x12\x1f\n\x04\x63ron\x18\x06 \x01(\x0b\x32\x11.pps_v2.CronInput\"T\n\x08JobInput\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1e\n\x06\x63ommit\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0c\n\x04glob\x18\x03 \x01(\t\x12\x0c\n\x04lazy\x18\x04 \x01(\x08\"#\n\x0fParallelismSpec\x12\x10\n\x08\x63onstant\x18\x01 \x01(\x04\"\'\n\tInputFile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04hash\x18\x02 \x01(\x0c\"-\n\x05\x44\x61tum\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\n\n\x02id\x18\x02 \x01(\t\"\xc4\x01\n\tDatumInfo\x12\x1c\n\x05\x64\x61tum\x18\x01 \x01(\x0b\x32\r.pps_v2.Datum\x12!\n\x05state\x18\x02 \x01(\x0e\x32\x12.pps_v2.DatumState\x12#\n\x05stats\x18\x03 \x01(\x0b\x32\x14.pps_v2.ProcessStats\x12\x1f\n\tpfs_state\x18\x04 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x1e\n\x04\x64\x61ta\x18\x05 \x03(\x0b\x32\x10.pfs_v2.FileInfo\x12\x10\n\x08image_id\x18\x06 \x01(\t\"s\n\tAggregate\x12\r\n\x05\x63ount\x18\x01 \x01(\x03\x12\x0c\n\x04mean\x18\x02 \x01(\x01\x12\x0e\n\x06stddev\x18\x03 \x01(\x01\x12\x18\n\x10\x66ifth_percentile\x18\x04 \x01(\x01\x12\x1f\n\x17ninety_fifth_percentile\x18\x05 \x01(\x01\"\xcf\x01\n\x0cProcessStats\x12\x30\n\rdownload_time\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12/\n\x0cprocess_time\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bupload_time\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x16\n\x0e\x64ownload_bytes\x18\x04 \x01(\x03\x12\x14\n\x0cupload_bytes\x18\x05 \x01(\x03\"\xe6\x01\n\x15\x41ggregateProcessStats\x12(\n\rdownload_time\x18\x01 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12\'\n\x0cprocess_time\x18\x02 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12&\n\x0bupload_time\x18\x03 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12)\n\x0e\x64ownload_bytes\x18\x04 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12\'\n\x0cupload_bytes\x18\x05 \x01(\x0b\x32\x11.pps_v2.Aggregate\"\\\n\x0cWorkerStatus\x12\x11\n\tworker_id\x18\x01 \x01(\t\x12\x0e\n\x06job_id\x18\x02 \x01(\t\x12)\n\x0c\x64\x61tum_status\x18\x03 \x01(\x0b\x32\x13.pps_v2.DatumStatus\"[\n\x0b\x44\x61tumStatus\x12+\n\x07started\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x11.pps_v2.InputFile\"W\n\x0cResourceSpec\x12\x0b\n\x03\x63pu\x18\x01 \x01(\x02\x12\x0e\n\x06memory\x18\x02 \x01(\t\x12\x1c\n\x03gpu\x18\x03 \x01(\x0b\x32\x0f.pps_v2.GPUSpec\x12\x0c\n\x04\x64isk\x18\x04 \x01(\t\"\'\n\x07GPUSpec\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0e\n\x06number\x18\x02 \x01(\x03\"L\n\nJobSetInfo\x12\x1f\n\x07job_set\x18\x01 \x01(\x0b\x32\x0e.pps_v2.JobSet\x12\x1d\n\x04jobs\x18\x02 \x03(\x0b\x32\x0f.pps_v2.JobInfo\"\xd5\t\n\x07JobInfo\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x18\n\x10pipeline_version\x18\x02 \x01(\x04\x12%\n\routput_commit\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07restart\x18\x04 \x01(\x04\x12\x16\n\x0e\x64\x61ta_processed\x18\x05 \x01(\x03\x12\x14\n\x0c\x64\x61ta_skipped\x18\x06 \x01(\x03\x12\x12\n\ndata_total\x18\x07 \x01(\x03\x12\x13\n\x0b\x64\x61ta_failed\x18\x08 \x01(\x03\x12\x16\n\x0e\x64\x61ta_recovered\x18\t \x01(\x03\x12#\n\x05stats\x18\n \x01(\x0b\x32\x14.pps_v2.ProcessStats\x12\x1f\n\x05state\x18\x0b \x01(\x0e\x32\x10.pps_v2.JobState\x12\x0e\n\x06reason\x18\x0c \x01(\t\x12+\n\x07\x63reated\x18\r \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\x07started\x18\x0e \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x66inished\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12(\n\x07\x64\x65tails\x18\x10 \x01(\x0b\x32\x17.pps_v2.JobInfo.Details\x1a\xe6\x05\n\x07\x44\x65tails\x12$\n\ttransform\x18\x01 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x31\n\x10parallelism_spec\x18\x02 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x03 \x01(\x0b\x32\x0e.pps_v2.Egress\x12 \n\x07service\x18\x04 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x05 \x01(\x0b\x32\r.pps_v2.Spout\x12+\n\rworker_status\x18\x06 \x03(\x0b\x32\x14.pps_v2.WorkerStatus\x12/\n\x11resource_requests\x18\x07 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\x08 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\t \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\n \x01(\x0b\x32\r.pps_v2.Input\x12\x0c\n\x04salt\x18\x0b \x01(\t\x12,\n\x0e\x64\x61tum_set_spec\x18\x0c \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\r \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x0e \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x0b\x64\x61tum_tries\x18\x0f \x01(\x03\x12/\n\x0fscheduling_spec\x18\x10 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x11 \x01(\t\x12\x11\n\tpod_patch\x18\x12 \x01(\t\x12\x37\n\x19sidecar_resource_requests\x18\x13 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\":\n\x06Worker\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x05state\x18\x02 \x01(\x0e\x32\x13.pps_v2.WorkerState\":\n\x08Pipeline\x12 \n\x07project\x18\x02 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xb4\x01\n\nToleration\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x08operator\x18\x02 \x01(\x0e\x32\x1a.pps_v2.TolerationOperator\x12\r\n\x05value\x18\x03 \x01(\t\x12#\n\x06\x65\x66\x66\x65\x63t\x18\x04 \x01(\x0e\x32\x13.pps_v2.TaintEffect\x12\x37\n\x12toleration_seconds\x18\x05 \x01(\x0b\x32\x1b.google.protobuf.Int64Value\"\xad\x0c\n\x0cPipelineInfo\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07version\x18\x02 \x01(\x04\x12#\n\x0bspec_commit\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07stopped\x18\x04 \x01(\x08\x12$\n\x05state\x18\x05 \x01(\x0e\x32\x15.pps_v2.PipelineState\x12\x0e\n\x06reason\x18\x06 \x01(\t\x12(\n\x0elast_job_state\x18\x08 \x01(\x0e\x32\x10.pps_v2.JobState\x12\x13\n\x0bparallelism\x18\t \x01(\x04\x12/\n\x04type\x18\n \x01(\x0e\x32!.pps_v2.PipelineInfo.PipelineType\x12\x12\n\nauth_token\x18\x0b \x01(\t\x12-\n\x07\x64\x65tails\x18\x0c \x01(\x0b\x32\x1c.pps_v2.PipelineInfo.Details\x1a\xc6\x08\n\x07\x44\x65tails\x12$\n\ttransform\x18\x01 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x1d\n\x06tf_job\x18\x02 \x01(\x0b\x32\r.pps_v2.TFJob\x12\x31\n\x10parallelism_spec\x18\x03 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x04 \x01(\x0b\x32\x0e.pps_v2.Egress\x12.\n\ncreated_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x14\n\x0crecent_error\x18\x06 \x01(\t\x12\x19\n\x11workers_requested\x18\x07 \x01(\x03\x12\x19\n\x11workers_available\x18\x08 \x01(\x03\x12\x15\n\routput_branch\x18\t \x01(\t\x12/\n\x11resource_requests\x18\n \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\x0b \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\x0c \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\r \x01(\x0b\x32\r.pps_v2.Input\x12\x13\n\x0b\x64\x65scription\x18\x0e \x01(\t\x12\x0c\n\x04salt\x18\x10 \x01(\t\x12\x0e\n\x06reason\x18\x11 \x01(\t\x12 \n\x07service\x18\x13 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x14 \x01(\x0b\x32\r.pps_v2.Spout\x12,\n\x0e\x64\x61tum_set_spec\x18\x15 \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\x16 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x17 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x0b\x64\x61tum_tries\x18\x18 \x01(\x03\x12/\n\x0fscheduling_spec\x18\x19 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x1a \x01(\t\x12\x11\n\tpod_patch\x18\x1b \x01(\t\x12\x0e\n\x06s3_out\x18\x1c \x01(\x08\x12\"\n\x08metadata\x18\x1d \x01(\x0b\x32\x10.pps_v2.Metadata\x12\x16\n\x0ereprocess_spec\x18\x1e \x01(\t\x12\x17\n\x0funclaimed_tasks\x18\x1f \x01(\x03\x12\x11\n\tworker_rc\x18  \x01(\t\x12\x13\n\x0b\x61utoscaling\x18! \x01(\x08\x12\'\n\x0btolerations\x18\" \x03(\x0b\x32\x12.pps_v2.Toleration\x12\x37\n\x19sidecar_resource_requests\x18# \x01(\x0b\x32\x14.pps_v2.ResourceSpec\"z\n\x0cPipelineType\x12\x19\n\x15PIPELINT_TYPE_UNKNOWN\x10\x00\x12\x1b\n\x17PIPELINE_TYPE_TRANSFORM\x10\x01\x12\x17\n\x13PIPELINE_TYPE_SPOUT\x10\x02\x12\x19\n\x15PIPELINE_TYPE_SERVICE\x10\x03J\x04\x08\x07\x10\x08\"<\n\rPipelineInfos\x12+\n\rpipeline_info\x18\x01 \x03(\x0b\x32\x14.pps_v2.PipelineInfo\"\x14\n\x06JobSet\x12\n\n\x02id\x18\x01 \x01(\t\"V\n\x14InspectJobSetRequest\x12\x1f\n\x07job_set\x18\x01 \x01(\x0b\x32\x0e.pps_v2.JobSet\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\"\x9e\x01\n\x11ListJobSetRequest\x12\x0f\n\x07\x64\x65tails\x18\x01 \x01(\x08\x12!\n\x08projects\x18\x02 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\x34\n\x10paginationMarker\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\"L\n\x11InspectJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\"\x88\x02\n\x0eListJobRequest\x12!\n\x08projects\x18\x07 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12$\n\x0cinput_commit\x18\x02 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07history\x18\x04 \x01(\x03\x12\x0f\n\x07\x64\x65tails\x18\x05 \x01(\x08\x12\x10\n\x08jqFilter\x18\x06 \x01(\t\x12\x34\n\x10paginationMarker\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06number\x18\t \x01(\x03\x12\x0f\n\x07reverse\x18\n \x01(\x08\"J\n\x13SubscribeJobRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07\x64\x65tails\x18\x02 \x01(\x08\",\n\x10\x44\x65leteJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\":\n\x0eStopJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x0e\n\x06reason\x18\x03 \x01(\t\"\x87\x02\n\x15UpdateJobStateRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x1f\n\x05state\x18\x02 \x01(\x0e\x32\x10.pps_v2.JobState\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x0f\n\x07restart\x18\x05 \x01(\x04\x12\x16\n\x0e\x64\x61ta_processed\x18\x06 \x01(\x03\x12\x14\n\x0c\x64\x61ta_skipped\x18\x07 \x01(\x03\x12\x13\n\x0b\x64\x61ta_failed\x18\x08 \x01(\x03\x12\x16\n\x0e\x64\x61ta_recovered\x18\t \x01(\x03\x12\x12\n\ndata_total\x18\n \x01(\x03\x12#\n\x05stats\x18\x0b \x01(\x0b\x32\x14.pps_v2.ProcessStats\"\xf4\x01\n\x0eGetLogsRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x18\n\x03job\x18\x02 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x14\n\x0c\x64\x61ta_filters\x18\x03 \x03(\t\x12\x1c\n\x05\x64\x61tum\x18\x04 \x01(\x0b\x32\r.pps_v2.Datum\x12\x0e\n\x06master\x18\x05 \x01(\x08\x12\x0e\n\x06\x66ollow\x18\x06 \x01(\x08\x12\x0c\n\x04tail\x18\x07 \x01(\x03\x12\x18\n\x10use_loki_backend\x18\x08 \x01(\x08\x12(\n\x05since\x18\t \x01(\x0b\x32\x19.google.protobuf.Duration\"\xe6\x01\n\nLogMessage\x12\x14\n\x0cproject_name\x18\n \x01(\t\x12\x15\n\rpipeline_name\x18\x01 \x01(\t\x12\x0e\n\x06job_id\x18\x02 \x01(\t\x12\x11\n\tworker_id\x18\x03 \x01(\t\x12\x10\n\x08\x64\x61tum_id\x18\x04 \x01(\t\x12\x0e\n\x06master\x18\x05 \x01(\x08\x12\x1f\n\x04\x64\x61ta\x18\x06 \x03(\x0b\x32\x11.pps_v2.InputFile\x12\x0c\n\x04user\x18\x07 \x01(\x08\x12&\n\x02ts\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\t \x01(\t\"E\n\x13RestartDatumRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x14\n\x0c\x64\x61ta_filters\x18\x02 \x03(\t\"3\n\x13InspectDatumRequest\x12\x1c\n\x05\x64\x61tum\x18\x01 \x01(\x0b\x32\r.pps_v2.Datum\"\xe3\x01\n\x10ListDatumRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x1c\n\x05input\x18\x02 \x01(\x0b\x32\r.pps_v2.Input\x12/\n\x06\x66ilter\x18\x03 \x01(\x0b\x32\x1f.pps_v2.ListDatumRequest.Filter\x12\x18\n\x10paginationMarker\x18\x04 \x01(\t\x12\x0e\n\x06number\x18\x05 \x01(\x03\x12\x0f\n\x07reverse\x18\x06 \x01(\x08\x1a+\n\x06\x46ilter\x12!\n\x05state\x18\x01 \x03(\x0e\x32\x12.pps_v2.DatumState\"F\n\x0c\x44\x61tumSetSpec\x12\x0e\n\x06number\x18\x01 \x01(\x03\x12\x12\n\nsize_bytes\x18\x02 \x01(\x03\x12\x12\n\nper_worker\x18\x03 \x01(\x03\"\xa3\x01\n\x0eSchedulingSpec\x12?\n\rnode_selector\x18\x01 \x03(\x0b\x32(.pps_v2.SchedulingSpec.NodeSelectorEntry\x12\x1b\n\x13priority_class_name\x18\x02 \x01(\t\x1a\x33\n\x11NodeSelectorEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x88\x08\n\x15\x43reatePipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x1d\n\x06tf_job\x18\x02 \x01(\x0b\x32\r.pps_v2.TFJob\x12$\n\ttransform\x18\x03 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x31\n\x10parallelism_spec\x18\x04 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x05 \x01(\x0b\x32\x0e.pps_v2.Egress\x12\x0e\n\x06update\x18\x06 \x01(\x08\x12\x15\n\routput_branch\x18\x07 \x01(\t\x12\x0e\n\x06s3_out\x18\x08 \x01(\x08\x12/\n\x11resource_requests\x18\t \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\n \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\x0b \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\x0c \x01(\x0b\x32\r.pps_v2.Input\x12\x13\n\x0b\x64\x65scription\x18\r \x01(\t\x12\x11\n\treprocess\x18\x0f \x01(\x08\x12 \n\x07service\x18\x11 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x12 \x01(\x0b\x32\r.pps_v2.Spout\x12,\n\x0e\x64\x61tum_set_spec\x18\x13 \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\x14 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x15 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x0c\n\x04salt\x18\x16 \x01(\t\x12\x13\n\x0b\x64\x61tum_tries\x18\x17 \x01(\x03\x12/\n\x0fscheduling_spec\x18\x18 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x19 \x01(\t\x12\x11\n\tpod_patch\x18\x1a \x01(\t\x12#\n\x0bspec_commit\x18\x1b \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\x08metadata\x18\x1c \x01(\x0b\x32\x10.pps_v2.Metadata\x12\x16\n\x0ereprocess_spec\x18\x1d \x01(\t\x12\x13\n\x0b\x61utoscaling\x18\x1e \x01(\x08\x12\'\n\x0btolerations\x18\" \x03(\x0b\x32\x12.pps_v2.Toleration\x12\x37\n\x19sidecar_resource_requests\x18# \x01(\x0b\x32\x14.pps_v2.ResourceSpec\"M\n\x16InspectPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07\x64\x65tails\x18\x02 \x01(\x08\"\xb7\x01\n\x13ListPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07history\x18\x02 \x01(\x03\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\x12\x10\n\x08jqFilter\x18\x04 \x01(\t\x12%\n\ncommit_set\x18\x05 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12!\n\x08projects\x18\x06 \x03(\x0b\x32\x0f.pfs_v2.Project\"n\n\x15\x44\x65letePipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x03\x61ll\x18\x02 \x01(\x08\x42\x02\x18\x01\x12\r\n\x05\x66orce\x18\x03 \x01(\x08\x12\x11\n\tkeep_repo\x18\x04 \x01(\x08\"j\n\x16\x44\x65letePipelinesRequest\x12!\n\x08projects\x18\x01 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x11\n\tkeep_repo\x18\x03 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x04 \x01(\x08\">\n\x17\x44\x65letePipelinesResponse\x12#\n\tpipelines\x18\x01 \x03(\x0b\x32\x10.pps_v2.Pipeline\":\n\x14StartPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"9\n\x13StopPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"l\n\x12RunPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\"\n\nprovenance\x18\x02 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\x0e\n\x06job_id\x18\x03 \x01(\t\"4\n\x0eRunCronRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"#\n\x13\x43reateSecretRequest\x12\x0c\n\x04\x66ile\x18\x01 \x01(\x0c\"5\n\x13\x44\x65leteSecretRequest\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\"6\n\x14InspectSecretRequest\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\"\x16\n\x06Secret\x12\x0c\n\x04name\x18\x01 \x01(\t\"r\n\nSecretInfo\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x36\n\x12\x63reation_timestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"6\n\x0bSecretInfos\x12\'\n\x0bsecret_info\x18\x01 \x03(\x0b\x32\x12.pps_v2.SecretInfo\"\x15\n\x13\x41\x63tivateAuthRequest\"\x16\n\x14\x41\x63tivateAuthResponse\"\x81\x01\n\x12RunLoadTestRequest\x12\x10\n\x08\x64\x61g_spec\x18\x01 \x01(\t\x12\x11\n\tload_spec\x18\x02 \x01(\t\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\x13\n\x0bparallelism\x18\x04 \x01(\x03\x12\x11\n\tpod_patch\x18\x05 \x01(\t\x12\x10\n\x08state_id\x18\x06 \x01(\t\"6\n\x13RunLoadTestResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\x12\x10\n\x08state_id\x18\x02 \x01(\t\"\x8d\x01\n\x15RenderTemplateRequest\x12\x10\n\x08template\x18\x01 \x01(\t\x12\x35\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\'.pps_v2.RenderTemplateRequest.ArgsEntry\x1a+\n\tArgsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"T\n\x16RenderTemplateResponse\x12\x0c\n\x04json\x18\x01 \x01(\t\x12,\n\x05specs\x18\x02 \x03(\x0b\x32\x1d.pps_v2.CreatePipelineRequest\"F\n\x0bLokiRequest\x12(\n\x05since\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\r\n\x05query\x18\x02 \x01(\t\"!\n\x0eLokiLogMessage\x12\x0f\n\x07message\x18\x01 \x01(\t*\xc1\x01\n\x08JobState\x12\x15\n\x11JOB_STATE_UNKNOWN\x10\x00\x12\x0f\n\x0bJOB_CREATED\x10\x01\x12\x10\n\x0cJOB_STARTING\x10\x02\x12\x0f\n\x0bJOB_RUNNING\x10\x03\x12\x0f\n\x0bJOB_FAILURE\x10\x04\x12\x0f\n\x0bJOB_SUCCESS\x10\x05\x12\x0e\n\nJOB_KILLED\x10\x06\x12\x11\n\rJOB_EGRESSING\x10\x07\x12\x11\n\rJOB_FINISHING\x10\x08\x12\x12\n\x0eJOB_UNRUNNABLE\x10\t*\\\n\nDatumState\x12\x0b\n\x07UNKNOWN\x10\x00\x12\n\n\x06\x46\x41ILED\x10\x01\x12\x0b\n\x07SUCCESS\x10\x02\x12\x0b\n\x07SKIPPED\x10\x03\x12\x0c\n\x08STARTING\x10\x04\x12\r\n\tRECOVERED\x10\x05*Y\n\x0bWorkerState\x12\x18\n\x14WORKER_STATE_UNKNOWN\x10\x00\x12\x0f\n\x0bPOD_RUNNING\x10\x01\x12\x0f\n\x0bPOD_SUCCESS\x10\x02\x12\x0e\n\nPOD_FAILED\x10\x03*\xc9\x01\n\rPipelineState\x12\x1a\n\x16PIPELINE_STATE_UNKNOWN\x10\x00\x12\x15\n\x11PIPELINE_STARTING\x10\x01\x12\x14\n\x10PIPELINE_RUNNING\x10\x02\x12\x17\n\x13PIPELINE_RESTARTING\x10\x03\x12\x14\n\x10PIPELINE_FAILURE\x10\x04\x12\x13\n\x0fPIPELINE_PAUSED\x10\x05\x12\x14\n\x10PIPELINE_STANDBY\x10\x06\x12\x15\n\x11PIPELINE_CRASHING\x10\x07*6\n\x12TolerationOperator\x12\t\n\x05\x45MPTY\x10\x00\x12\n\n\x06\x45XISTS\x10\x01\x12\t\n\x05\x45QUAL\x10\x02*W\n\x0bTaintEffect\x12\x0f\n\x0b\x41LL_EFFECTS\x10\x00\x12\x0f\n\x0bNO_SCHEDULE\x10\x01\x12\x16\n\x12PREFER_NO_SCHEDULE\x10\x02\x12\x0e\n\nNO_EXECUTE\x10\x03\x32\xde\x11\n\x03\x41PI\x12:\n\nInspectJob\x12\x19.pps_v2.InspectJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x12\x42\n\rInspectJobSet\x12\x1c.pps_v2.InspectJobSetRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12\x36\n\x07ListJob\x12\x16.pps_v2.ListJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12?\n\nListJobSet\x12\x19.pps_v2.ListJobSetRequest\x1a\x12.pps_v2.JobSetInfo\"\x00\x30\x01\x12@\n\x0cSubscribeJob\x12\x1b.pps_v2.SubscribeJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12?\n\tDeleteJob\x12\x18.pps_v2.DeleteJobRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\x07StopJob\x12\x16.pps_v2.StopJobRequest\x1a\x16.google.protobuf.Empty\"\x00\x12@\n\x0cInspectDatum\x12\x1b.pps_v2.InspectDatumRequest\x1a\x11.pps_v2.DatumInfo\"\x00\x12<\n\tListDatum\x12\x18.pps_v2.ListDatumRequest\x1a\x11.pps_v2.DatumInfo\"\x00\x30\x01\x12\x45\n\x0cRestartDatum\x12\x1b.pps_v2.RestartDatumRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n\x0e\x43reatePipeline\x12\x1d.pps_v2.CreatePipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n\x0fInspectPipeline\x12\x1e.pps_v2.InspectPipelineRequest\x1a\x14.pps_v2.PipelineInfo\"\x00\x12\x45\n\x0cListPipeline\x12\x1b.pps_v2.ListPipelineRequest\x1a\x14.pps_v2.PipelineInfo\"\x00\x30\x01\x12I\n\x0e\x44\x65letePipeline\x12\x1d.pps_v2.DeletePipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12T\n\x0f\x44\x65letePipelines\x12\x1e.pps_v2.DeletePipelinesRequest\x1a\x1f.pps_v2.DeletePipelinesResponse\"\x00\x12G\n\rStartPipeline\x12\x1c.pps_v2.StartPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0cStopPipeline\x12\x1b.pps_v2.StopPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\x0bRunPipeline\x12\x1a.pps_v2.RunPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\x07RunCron\x12\x16.pps_v2.RunCronRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0c\x43reateSecret\x12\x1b.pps_v2.CreateSecretRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0c\x44\x65leteSecret\x12\x1b.pps_v2.DeleteSecretRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\nListSecret\x12\x16.google.protobuf.Empty\x1a\x13.pps_v2.SecretInfos\"\x00\x12\x43\n\rInspectSecret\x12\x1c.pps_v2.InspectSecretRequest\x1a\x12.pps_v2.SecretInfo\"\x00\x12=\n\tDeleteAll\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12\x39\n\x07GetLogs\x12\x16.pps_v2.GetLogsRequest\x1a\x12.pps_v2.LogMessage\"\x00\x30\x01\x12K\n\x0c\x41\x63tivateAuth\x12\x1b.pps_v2.ActivateAuthRequest\x1a\x1c.pps_v2.ActivateAuthResponse\"\x00\x12I\n\x0eUpdateJobState\x12\x1d.pps_v2.UpdateJobStateRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0bRunLoadTest\x12\x1a.pps_v2.RunLoadTestRequest\x1a\x1b.pps_v2.RunLoadTestResponse\"\x00\x12K\n\x12RunLoadTestDefault\x12\x16.google.protobuf.Empty\x1a\x1b.pps_v2.RunLoadTestResponse\"\x00\x12Q\n\x0eRenderTemplate\x12\x1d.pps_v2.RenderTemplateRequest\x1a\x1e.pps_v2.RenderTemplateResponse\"\x00\x12;\n\x08ListTask\x12\x18.taskapi.ListTaskRequest\x1a\x11.taskapi.TaskInfo\"\x00\x30\x01\x12@\n\rGetKubeEvents\x12\x13.pps_v2.LokiRequest\x1a\x16.pps_v2.LokiLogMessage\"\x00\x30\x01\x12<\n\tQueryLoki\x12\x13.pps_v2.LokiRequest\x1a\x16.pps_v2.LokiLogMessage\"\x00\x30\x01\x42+Z)github.com/pachyderm/pachyderm/v2/src/ppsb\x06proto3'
+  serialized_pb=b'\n\'python_pachyderm/proto/v2/pps/pps.proto\x12\x06pps_v2\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\'python_pachyderm/proto/v2/pfs/pfs.proto\x1a)python_pachyderm/proto/v2/task/task.proto\"M\n\x0bSecretMount\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03key\x18\x02 \x01(\t\x12\x12\n\nmount_path\x18\x03 \x01(\t\x12\x0f\n\x07\x65nv_var\x18\x04 \x01(\t\"\x82\x03\n\tTransform\x12\r\n\x05image\x18\x01 \x01(\t\x12\x0b\n\x03\x63md\x18\x02 \x03(\t\x12\x0f\n\x07\x65rr_cmd\x18\x03 \x03(\t\x12\'\n\x03\x65nv\x18\x04 \x03(\x0b\x32\x1a.pps_v2.Transform.EnvEntry\x12$\n\x07secrets\x18\x05 \x03(\x0b\x32\x13.pps_v2.SecretMount\x12\x1a\n\x12image_pull_secrets\x18\x06 \x03(\t\x12\r\n\x05stdin\x18\x07 \x03(\t\x12\x11\n\terr_stdin\x18\x08 \x03(\t\x12\x1a\n\x12\x61\x63\x63\x65pt_return_code\x18\t \x03(\x03\x12\r\n\x05\x64\x65\x62ug\x18\n \x01(\x08\x12\x0c\n\x04user\x18\x0b \x01(\t\x12\x13\n\x0bworking_dir\x18\x0c \x01(\t\x12\x12\n\ndockerfile\x18\r \x01(\t\x12\x15\n\rmemory_volume\x18\x0e \x01(\x08\x12\x16\n\x0e\x64\x61tum_batching\x18\x0f \x01(\x08\x1a*\n\x08\x45nvEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x17\n\x05TFJob\x12\x0e\n\x06tf_job\x18\x01 \x01(\t\"\x89\x01\n\x06\x45gress\x12\x0b\n\x03URL\x18\x01 \x01(\t\x12\x35\n\x0eobject_storage\x18\x02 \x01(\x0b\x32\x1b.pfs_v2.ObjectStorageEgressH\x00\x12\x31\n\x0csql_database\x18\x03 \x01(\x0b\x32\x19.pfs_v2.SQLDatabaseEgressH\x00\x42\x08\n\x06target\" \n\nDetermined\x12\x12\n\nworkspaces\x18\x01 \x03(\t\"5\n\x03Job\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\n\n\x02id\x18\x02 \x01(\t\"\xd3\x01\n\x08Metadata\x12\x36\n\x0b\x61nnotations\x18\x01 \x03(\x0b\x32!.pps_v2.Metadata.AnnotationsEntry\x12,\n\x06labels\x18\x02 \x03(\x0b\x32\x1c.pps_v2.Metadata.LabelsEntry\x1a\x32\n\x10\x41nnotationsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"Q\n\x07Service\x12\x15\n\rinternal_port\x18\x01 \x01(\x05\x12\x15\n\rexternal_port\x18\x02 \x01(\x05\x12\n\n\x02ip\x18\x03 \x01(\t\x12\x0c\n\x04type\x18\x04 \x01(\t\")\n\x05Spout\x12 \n\x07service\x18\x01 \x01(\x0b\x32\x0f.pps_v2.Service\"\x80\x02\n\x08PFSInput\x12\x0f\n\x07project\x18\x0e \x01(\t\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x11\n\trepo_type\x18\r \x01(\t\x12\x0e\n\x06\x62ranch\x18\x03 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x04 \x01(\t\x12\x0c\n\x04glob\x18\x05 \x01(\t\x12\x0f\n\x07join_on\x18\x06 \x01(\t\x12\x12\n\nouter_join\x18\x07 \x01(\x08\x12\x10\n\x08group_by\x18\x08 \x01(\t\x12\x0c\n\x04lazy\x18\t \x01(\x08\x12\x13\n\x0b\x65mpty_files\x18\n \x01(\x08\x12\n\n\x02s3\x18\x0b \x01(\x08\x12 \n\x07trigger\x18\x0c \x01(\x0b\x32\x0f.pfs_v2.Trigger\"\x94\x01\n\tCronInput\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x07 \x01(\t\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x03 \x01(\t\x12\x0c\n\x04spec\x18\x04 \x01(\t\x12\x11\n\toverwrite\x18\x05 \x01(\x08\x12)\n\x05start\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xbe\x01\n\x05Input\x12\x1d\n\x03pfs\x18\x01 \x01(\x0b\x32\x10.pps_v2.PFSInput\x12\x1b\n\x04join\x18\x02 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05group\x18\x03 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05\x63ross\x18\x04 \x03(\x0b\x32\r.pps_v2.Input\x12\x1c\n\x05union\x18\x05 \x03(\x0b\x32\r.pps_v2.Input\x12\x1f\n\x04\x63ron\x18\x06 \x01(\x0b\x32\x11.pps_v2.CronInput\"T\n\x08JobInput\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1e\n\x06\x63ommit\x18\x02 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0c\n\x04glob\x18\x03 \x01(\t\x12\x0c\n\x04lazy\x18\x04 \x01(\x08\"#\n\x0fParallelismSpec\x12\x10\n\x08\x63onstant\x18\x01 \x01(\x04\"\'\n\tInputFile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04hash\x18\x02 \x01(\x0c\"-\n\x05\x44\x61tum\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\n\n\x02id\x18\x02 \x01(\t\"\xc4\x01\n\tDatumInfo\x12\x1c\n\x05\x64\x61tum\x18\x01 \x01(\x0b\x32\r.pps_v2.Datum\x12!\n\x05state\x18\x02 \x01(\x0e\x32\x12.pps_v2.DatumState\x12#\n\x05stats\x18\x03 \x01(\x0b\x32\x14.pps_v2.ProcessStats\x12\x1f\n\tpfs_state\x18\x04 \x01(\x0b\x32\x0c.pfs_v2.File\x12\x1e\n\x04\x64\x61ta\x18\x05 \x03(\x0b\x32\x10.pfs_v2.FileInfo\x12\x10\n\x08image_id\x18\x06 \x01(\t\"s\n\tAggregate\x12\r\n\x05\x63ount\x18\x01 \x01(\x03\x12\x0c\n\x04mean\x18\x02 \x01(\x01\x12\x0e\n\x06stddev\x18\x03 \x01(\x01\x12\x18\n\x10\x66ifth_percentile\x18\x04 \x01(\x01\x12\x1f\n\x17ninety_fifth_percentile\x18\x05 \x01(\x01\"\xcf\x01\n\x0cProcessStats\x12\x30\n\rdownload_time\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12/\n\x0cprocess_time\x18\x02 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bupload_time\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x16\n\x0e\x64ownload_bytes\x18\x04 \x01(\x03\x12\x14\n\x0cupload_bytes\x18\x05 \x01(\x03\"\xe6\x01\n\x15\x41ggregateProcessStats\x12(\n\rdownload_time\x18\x01 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12\'\n\x0cprocess_time\x18\x02 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12&\n\x0bupload_time\x18\x03 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12)\n\x0e\x64ownload_bytes\x18\x04 \x01(\x0b\x32\x11.pps_v2.Aggregate\x12\'\n\x0cupload_bytes\x18\x05 \x01(\x0b\x32\x11.pps_v2.Aggregate\"\\\n\x0cWorkerStatus\x12\x11\n\tworker_id\x18\x01 \x01(\t\x12\x0e\n\x06job_id\x18\x02 \x01(\t\x12)\n\x0c\x64\x61tum_status\x18\x03 \x01(\x0b\x32\x13.pps_v2.DatumStatus\"[\n\x0b\x44\x61tumStatus\x12+\n\x07started\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x11.pps_v2.InputFile\"W\n\x0cResourceSpec\x12\x0b\n\x03\x63pu\x18\x01 \x01(\x02\x12\x0e\n\x06memory\x18\x02 \x01(\t\x12\x1c\n\x03gpu\x18\x03 \x01(\x0b\x32\x0f.pps_v2.GPUSpec\x12\x0c\n\x04\x64isk\x18\x04 \x01(\t\"\'\n\x07GPUSpec\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0e\n\x06number\x18\x02 \x01(\x03\"L\n\nJobSetInfo\x12\x1f\n\x07job_set\x18\x01 \x01(\x0b\x32\x0e.pps_v2.JobSet\x12\x1d\n\x04jobs\x18\x02 \x03(\x0b\x32\x0f.pps_v2.JobInfo\"\xe9\t\n\x07JobInfo\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x18\n\x10pipeline_version\x18\x02 \x01(\x04\x12%\n\routput_commit\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07restart\x18\x04 \x01(\x04\x12\x16\n\x0e\x64\x61ta_processed\x18\x05 \x01(\x03\x12\x14\n\x0c\x64\x61ta_skipped\x18\x06 \x01(\x03\x12\x12\n\ndata_total\x18\x07 \x01(\x03\x12\x13\n\x0b\x64\x61ta_failed\x18\x08 \x01(\x03\x12\x16\n\x0e\x64\x61ta_recovered\x18\t \x01(\x03\x12#\n\x05stats\x18\n \x01(\x0b\x32\x14.pps_v2.ProcessStats\x12\x1f\n\x05state\x18\x0b \x01(\x0e\x32\x10.pps_v2.JobState\x12\x0e\n\x06reason\x18\x0c \x01(\t\x12+\n\x07\x63reated\x18\r \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\x07started\x18\x0e \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x66inished\x18\x0f \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12(\n\x07\x64\x65tails\x18\x10 \x01(\x0b\x32\x17.pps_v2.JobInfo.Details\x12\x12\n\nauth_token\x18\x11 \x01(\t\x1a\xe6\x05\n\x07\x44\x65tails\x12$\n\ttransform\x18\x01 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x31\n\x10parallelism_spec\x18\x02 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x03 \x01(\x0b\x32\x0e.pps_v2.Egress\x12 \n\x07service\x18\x04 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x05 \x01(\x0b\x32\r.pps_v2.Spout\x12+\n\rworker_status\x18\x06 \x03(\x0b\x32\x14.pps_v2.WorkerStatus\x12/\n\x11resource_requests\x18\x07 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\x08 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\t \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\n \x01(\x0b\x32\r.pps_v2.Input\x12\x0c\n\x04salt\x18\x0b \x01(\t\x12,\n\x0e\x64\x61tum_set_spec\x18\x0c \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\r \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x0e \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x0b\x64\x61tum_tries\x18\x0f \x01(\x03\x12/\n\x0fscheduling_spec\x18\x10 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x11 \x01(\t\x12\x11\n\tpod_patch\x18\x12 \x01(\t\x12\x37\n\x19sidecar_resource_requests\x18\x13 \x01(\x0b\x32\x14.pps_v2.ResourceSpec\":\n\x06Worker\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x05state\x18\x02 \x01(\x0e\x32\x13.pps_v2.WorkerState\":\n\x08Pipeline\x12 \n\x07project\x18\x02 \x01(\x0b\x32\x0f.pfs_v2.Project\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xb4\x01\n\nToleration\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x08operator\x18\x02 \x01(\x0e\x32\x1a.pps_v2.TolerationOperator\x12\r\n\x05value\x18\x03 \x01(\t\x12#\n\x06\x65\x66\x66\x65\x63t\x18\x04 \x01(\x0e\x32\x13.pps_v2.TaintEffect\x12\x37\n\x12toleration_seconds\x18\x05 \x01(\x0b\x32\x1b.google.protobuf.Int64Value\"\xeb\x0c\n\x0cPipelineInfo\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07version\x18\x02 \x01(\x04\x12#\n\x0bspec_commit\x18\x03 \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07stopped\x18\x04 \x01(\x08\x12$\n\x05state\x18\x05 \x01(\x0e\x32\x15.pps_v2.PipelineState\x12\x0e\n\x06reason\x18\x06 \x01(\t\x12(\n\x0elast_job_state\x18\x08 \x01(\x0e\x32\x10.pps_v2.JobState\x12\x13\n\x0bparallelism\x18\t \x01(\x04\x12/\n\x04type\x18\n \x01(\x0e\x32!.pps_v2.PipelineInfo.PipelineType\x12\x12\n\nauth_token\x18\x0b \x01(\t\x12-\n\x07\x64\x65tails\x18\x0c \x01(\x0b\x32\x1c.pps_v2.PipelineInfo.Details\x12\x14\n\x0c\x64\x65tails_json\x18\r \x01(\t\x1a\xee\x08\n\x07\x44\x65tails\x12$\n\ttransform\x18\x01 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x1d\n\x06tf_job\x18\x02 \x01(\x0b\x32\r.pps_v2.TFJob\x12\x31\n\x10parallelism_spec\x18\x03 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x04 \x01(\x0b\x32\x0e.pps_v2.Egress\x12.\n\ncreated_at\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x14\n\x0crecent_error\x18\x06 \x01(\t\x12\x19\n\x11workers_requested\x18\x07 \x01(\x03\x12\x19\n\x11workers_available\x18\x08 \x01(\x03\x12\x15\n\routput_branch\x18\t \x01(\t\x12/\n\x11resource_requests\x18\n \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\x0b \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\x0c \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\r \x01(\x0b\x32\r.pps_v2.Input\x12\x13\n\x0b\x64\x65scription\x18\x0e \x01(\t\x12\x0c\n\x04salt\x18\x10 \x01(\t\x12\x0e\n\x06reason\x18\x11 \x01(\t\x12 \n\x07service\x18\x13 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x14 \x01(\x0b\x32\r.pps_v2.Spout\x12,\n\x0e\x64\x61tum_set_spec\x18\x15 \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\x16 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x17 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x0b\x64\x61tum_tries\x18\x18 \x01(\x03\x12/\n\x0fscheduling_spec\x18\x19 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x1a \x01(\t\x12\x11\n\tpod_patch\x18\x1b \x01(\t\x12\x0e\n\x06s3_out\x18\x1c \x01(\x08\x12\"\n\x08metadata\x18\x1d \x01(\x0b\x32\x10.pps_v2.Metadata\x12\x16\n\x0ereprocess_spec\x18\x1e \x01(\t\x12\x17\n\x0funclaimed_tasks\x18\x1f \x01(\x03\x12\x11\n\tworker_rc\x18  \x01(\t\x12\x13\n\x0b\x61utoscaling\x18! \x01(\x08\x12\'\n\x0btolerations\x18\" \x03(\x0b\x32\x12.pps_v2.Toleration\x12\x37\n\x19sidecar_resource_requests\x18# \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12&\n\ndetermined\x18$ \x01(\x0b\x32\x12.pps_v2.Determined\"z\n\x0cPipelineType\x12\x19\n\x15PIPELINT_TYPE_UNKNOWN\x10\x00\x12\x1b\n\x17PIPELINE_TYPE_TRANSFORM\x10\x01\x12\x17\n\x13PIPELINE_TYPE_SPOUT\x10\x02\x12\x19\n\x15PIPELINE_TYPE_SERVICE\x10\x03J\x04\x08\x07\x10\x08\"<\n\rPipelineInfos\x12+\n\rpipeline_info\x18\x01 \x03(\x0b\x32\x14.pps_v2.PipelineInfo\"\x14\n\x06JobSet\x12\n\n\x02id\x18\x01 \x01(\t\"V\n\x14InspectJobSetRequest\x12\x1f\n\x07job_set\x18\x01 \x01(\x0b\x32\x0e.pps_v2.JobSet\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\"\xb0\x01\n\x11ListJobSetRequest\x12\x0f\n\x07\x64\x65tails\x18\x01 \x01(\x08\x12!\n\x08projects\x18\x02 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\x34\n\x10paginationMarker\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06number\x18\x04 \x01(\x03\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\x12\x10\n\x08jqFilter\x18\x06 \x01(\t\"L\n\x11InspectJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\"\x88\x02\n\x0eListJobRequest\x12!\n\x08projects\x18\x07 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12$\n\x0cinput_commit\x18\x02 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\x0f\n\x07history\x18\x04 \x01(\x03\x12\x0f\n\x07\x64\x65tails\x18\x05 \x01(\x08\x12\x10\n\x08jqFilter\x18\x06 \x01(\t\x12\x34\n\x10paginationMarker\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06number\x18\t \x01(\x03\x12\x0f\n\x07reverse\x18\n \x01(\x08\"J\n\x13SubscribeJobRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07\x64\x65tails\x18\x02 \x01(\x08\",\n\x10\x44\x65leteJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\":\n\x0eStopJobRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x0e\n\x06reason\x18\x03 \x01(\t\"\x87\x02\n\x15UpdateJobStateRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x1f\n\x05state\x18\x02 \x01(\x0e\x32\x10.pps_v2.JobState\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x0f\n\x07restart\x18\x05 \x01(\x04\x12\x16\n\x0e\x64\x61ta_processed\x18\x06 \x01(\x03\x12\x14\n\x0c\x64\x61ta_skipped\x18\x07 \x01(\x03\x12\x13\n\x0b\x64\x61ta_failed\x18\x08 \x01(\x03\x12\x16\n\x0e\x64\x61ta_recovered\x18\t \x01(\x03\x12\x12\n\ndata_total\x18\n \x01(\x03\x12#\n\x05stats\x18\x0b \x01(\x0b\x32\x14.pps_v2.ProcessStats\"\xf4\x01\n\x0eGetLogsRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x18\n\x03job\x18\x02 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x14\n\x0c\x64\x61ta_filters\x18\x03 \x03(\t\x12\x1c\n\x05\x64\x61tum\x18\x04 \x01(\x0b\x32\r.pps_v2.Datum\x12\x0e\n\x06master\x18\x05 \x01(\x08\x12\x0e\n\x06\x66ollow\x18\x06 \x01(\x08\x12\x0c\n\x04tail\x18\x07 \x01(\x03\x12\x18\n\x10use_loki_backend\x18\x08 \x01(\x08\x12(\n\x05since\x18\t \x01(\x0b\x32\x19.google.protobuf.Duration\"\xe6\x01\n\nLogMessage\x12\x14\n\x0cproject_name\x18\n \x01(\t\x12\x15\n\rpipeline_name\x18\x01 \x01(\t\x12\x0e\n\x06job_id\x18\x02 \x01(\t\x12\x11\n\tworker_id\x18\x03 \x01(\t\x12\x10\n\x08\x64\x61tum_id\x18\x04 \x01(\t\x12\x0e\n\x06master\x18\x05 \x01(\x08\x12\x1f\n\x04\x64\x61ta\x18\x06 \x03(\x0b\x32\x11.pps_v2.InputFile\x12\x0c\n\x04user\x18\x07 \x01(\x08\x12&\n\x02ts\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\t \x01(\t\"E\n\x13RestartDatumRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x14\n\x0c\x64\x61ta_filters\x18\x02 \x03(\t\"3\n\x13InspectDatumRequest\x12\x1c\n\x05\x64\x61tum\x18\x01 \x01(\x0b\x32\r.pps_v2.Datum\"\xe3\x01\n\x10ListDatumRequest\x12\x18\n\x03job\x18\x01 \x01(\x0b\x32\x0b.pps_v2.Job\x12\x1c\n\x05input\x18\x02 \x01(\x0b\x32\r.pps_v2.Input\x12/\n\x06\x66ilter\x18\x03 \x01(\x0b\x32\x1f.pps_v2.ListDatumRequest.Filter\x12\x18\n\x10paginationMarker\x18\x04 \x01(\t\x12\x0e\n\x06number\x18\x05 \x01(\x03\x12\x0f\n\x07reverse\x18\x06 \x01(\x08\x1a+\n\x06\x46ilter\x12!\n\x05state\x18\x01 \x03(\x0e\x32\x12.pps_v2.DatumState\"F\n\x0c\x44\x61tumSetSpec\x12\x0e\n\x06number\x18\x01 \x01(\x03\x12\x12\n\nsize_bytes\x18\x02 \x01(\x03\x12\x12\n\nper_worker\x18\x03 \x01(\x03\"\xa3\x01\n\x0eSchedulingSpec\x12?\n\rnode_selector\x18\x01 \x03(\x0b\x32(.pps_v2.SchedulingSpec.NodeSelectorEntry\x12\x1b\n\x13priority_class_name\x18\x02 \x01(\t\x1a\x33\n\x11NodeSelectorEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xd7\x08\n\x15\x43reatePipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x1d\n\x06tf_job\x18\x02 \x01(\x0b\x32\r.pps_v2.TFJob\x12$\n\ttransform\x18\x03 \x01(\x0b\x32\x11.pps_v2.Transform\x12\x31\n\x10parallelism_spec\x18\x04 \x01(\x0b\x32\x17.pps_v2.ParallelismSpec\x12\x1e\n\x06\x65gress\x18\x05 \x01(\x0b\x32\x0e.pps_v2.Egress\x12\x0e\n\x06update\x18\x06 \x01(\x08\x12\x15\n\routput_branch\x18\x07 \x01(\t\x12\x0e\n\x06s3_out\x18\x08 \x01(\x08\x12/\n\x11resource_requests\x18\t \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12-\n\x0fresource_limits\x18\n \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x35\n\x17sidecar_resource_limits\x18\x0b \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x1c\n\x05input\x18\x0c \x01(\x0b\x32\r.pps_v2.Input\x12\x13\n\x0b\x64\x65scription\x18\r \x01(\t\x12\x11\n\treprocess\x18\x0f \x01(\x08\x12 \n\x07service\x18\x11 \x01(\x0b\x32\x0f.pps_v2.Service\x12\x1c\n\x05spout\x18\x12 \x01(\x0b\x32\r.pps_v2.Spout\x12,\n\x0e\x64\x61tum_set_spec\x18\x13 \x01(\x0b\x32\x14.pps_v2.DatumSetSpec\x12\x30\n\rdatum_timeout\x18\x14 \x01(\x0b\x32\x19.google.protobuf.Duration\x12.\n\x0bjob_timeout\x18\x15 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x0c\n\x04salt\x18\x16 \x01(\t\x12\x13\n\x0b\x64\x61tum_tries\x18\x17 \x01(\x03\x12/\n\x0fscheduling_spec\x18\x18 \x01(\x0b\x32\x16.pps_v2.SchedulingSpec\x12\x10\n\x08pod_spec\x18\x19 \x01(\t\x12\x11\n\tpod_patch\x18\x1a \x01(\t\x12#\n\x0bspec_commit\x18\x1b \x01(\x0b\x32\x0e.pfs_v2.Commit\x12\"\n\x08metadata\x18\x1c \x01(\x0b\x32\x10.pps_v2.Metadata\x12\x16\n\x0ereprocess_spec\x18\x1d \x01(\t\x12\x13\n\x0b\x61utoscaling\x18\x1e \x01(\x08\x12\'\n\x0btolerations\x18\" \x03(\x0b\x32\x12.pps_v2.Toleration\x12\x37\n\x19sidecar_resource_requests\x18# \x01(\x0b\x32\x14.pps_v2.ResourceSpec\x12\x14\n\x0c\x64\x65tails_json\x18$ \x01(\t\x12\x0f\n\x07\x64ry_run\x18% \x01(\x08\x12&\n\ndetermined\x18& \x01(\x0b\x32\x12.pps_v2.Determined\".\n\x16\x43reatePipelineResponse\x12\x14\n\x0c\x64\x65tails_json\x18\x01 \x01(\t\"M\n\x16InspectPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07\x64\x65tails\x18\x02 \x01(\x08\"\xb7\x01\n\x13ListPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x07history\x18\x02 \x01(\x03\x12\x0f\n\x07\x64\x65tails\x18\x03 \x01(\x08\x12\x10\n\x08jqFilter\x18\x04 \x01(\t\x12%\n\ncommit_set\x18\x05 \x01(\x0b\x32\x11.pfs_v2.CommitSet\x12!\n\x08projects\x18\x06 \x03(\x0b\x32\x0f.pfs_v2.Project\"n\n\x15\x44\x65letePipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\x0f\n\x03\x61ll\x18\x02 \x01(\x08\x42\x02\x18\x01\x12\r\n\x05\x66orce\x18\x03 \x01(\x08\x12\x11\n\tkeep_repo\x18\x04 \x01(\x08\"j\n\x16\x44\x65letePipelinesRequest\x12!\n\x08projects\x18\x01 \x03(\x0b\x32\x0f.pfs_v2.Project\x12\r\n\x05\x66orce\x18\x02 \x01(\x08\x12\x11\n\tkeep_repo\x18\x03 \x01(\x08\x12\x0b\n\x03\x61ll\x18\x04 \x01(\x08\">\n\x17\x44\x65letePipelinesResponse\x12#\n\tpipelines\x18\x01 \x03(\x0b\x32\x10.pps_v2.Pipeline\":\n\x14StartPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"9\n\x13StopPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"l\n\x12RunPipelineRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\x12\"\n\nprovenance\x18\x02 \x03(\x0b\x32\x0e.pfs_v2.Commit\x12\x0e\n\x06job_id\x18\x03 \x01(\t\"4\n\x0eRunCronRequest\x12\"\n\x08pipeline\x18\x01 \x01(\x0b\x32\x10.pps_v2.Pipeline\"#\n\x13\x43reateSecretRequest\x12\x0c\n\x04\x66ile\x18\x01 \x01(\x0c\"5\n\x13\x44\x65leteSecretRequest\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\"6\n\x14InspectSecretRequest\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\"\x16\n\x06Secret\x12\x0c\n\x04name\x18\x01 \x01(\t\"r\n\nSecretInfo\x12\x1e\n\x06secret\x18\x01 \x01(\x0b\x32\x0e.pps_v2.Secret\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x36\n\x12\x63reation_timestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"6\n\x0bSecretInfos\x12\'\n\x0bsecret_info\x18\x01 \x03(\x0b\x32\x12.pps_v2.SecretInfo\"\x15\n\x13\x41\x63tivateAuthRequest\"\x16\n\x14\x41\x63tivateAuthResponse\"\x81\x01\n\x12RunLoadTestRequest\x12\x10\n\x08\x64\x61g_spec\x18\x01 \x01(\t\x12\x11\n\tload_spec\x18\x02 \x01(\t\x12\x0c\n\x04seed\x18\x03 \x01(\x03\x12\x13\n\x0bparallelism\x18\x04 \x01(\x03\x12\x11\n\tpod_patch\x18\x05 \x01(\t\x12\x10\n\x08state_id\x18\x06 \x01(\t\"6\n\x13RunLoadTestResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\x12\x10\n\x08state_id\x18\x02 \x01(\t\"\x8d\x01\n\x15RenderTemplateRequest\x12\x10\n\x08template\x18\x01 \x01(\t\x12\x35\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\'.pps_v2.RenderTemplateRequest.ArgsEntry\x1a+\n\tArgsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"T\n\x16RenderTemplateResponse\x12\x0c\n\x04json\x18\x01 \x01(\t\x12,\n\x05specs\x18\x02 \x03(\x0b\x32\x1d.pps_v2.CreatePipelineRequest\"F\n\x0bLokiRequest\x12(\n\x05since\x18\x01 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\r\n\x05query\x18\x02 \x01(\t\"!\n\x0eLokiLogMessage\x12\x0f\n\x07message\x18\x01 \x01(\t\"G\n\x0f\x43lusterDefaults\x12\x14\n\x0c\x64\x65tails_json\x18\x01 \x01(\t\x12\x1e\n\x16\x65\x66\x66\x65\x63tive_details_json\x18\x02 \x01(\t\"\x1b\n\x19GetClusterDefaultsRequest\"O\n\x1aGetClusterDefaultsResponse\x12\x31\n\x10\x63luster_defaults\x18\x01 \x01(\x0b\x32\x17.pps_v2.ClusterDefaults\"\x86\x01\n\x19SetClusterDefaultsRequest\x12\x31\n\x10\x63luster_defaults\x18\x01 \x01(\x0b\x32\x17.pps_v2.ClusterDefaults\x12\x12\n\nregenerate\x18\x02 \x01(\x08\x12\x11\n\treprocess\x18\x03 \x01(\x08\x12\x0f\n\x07\x64ry_run\x18\x04 \x01(\x08\"j\n\x1aSetClusterDefaultsResponse\x12\x1e\n\x16\x65\x66\x66\x65\x63tive_details_json\x18\x01 \x01(\t\x12,\n\x12\x61\x66\x66\x65\x63ted_pipelines\x18\x02 \x03(\x0b\x32\x10.pps_v2.Pipeline*\xc1\x01\n\x08JobState\x12\x15\n\x11JOB_STATE_UNKNOWN\x10\x00\x12\x0f\n\x0bJOB_CREATED\x10\x01\x12\x10\n\x0cJOB_STARTING\x10\x02\x12\x0f\n\x0bJOB_RUNNING\x10\x03\x12\x0f\n\x0bJOB_FAILURE\x10\x04\x12\x0f\n\x0bJOB_SUCCESS\x10\x05\x12\x0e\n\nJOB_KILLED\x10\x06\x12\x11\n\rJOB_EGRESSING\x10\x07\x12\x11\n\rJOB_FINISHING\x10\x08\x12\x12\n\x0eJOB_UNRUNNABLE\x10\t*\\\n\nDatumState\x12\x0b\n\x07UNKNOWN\x10\x00\x12\n\n\x06\x46\x41ILED\x10\x01\x12\x0b\n\x07SUCCESS\x10\x02\x12\x0b\n\x07SKIPPED\x10\x03\x12\x0c\n\x08STARTING\x10\x04\x12\r\n\tRECOVERED\x10\x05*Y\n\x0bWorkerState\x12\x18\n\x14WORKER_STATE_UNKNOWN\x10\x00\x12\x0f\n\x0bPOD_RUNNING\x10\x01\x12\x0f\n\x0bPOD_SUCCESS\x10\x02\x12\x0e\n\nPOD_FAILED\x10\x03*\xc9\x01\n\rPipelineState\x12\x1a\n\x16PIPELINE_STATE_UNKNOWN\x10\x00\x12\x15\n\x11PIPELINE_STARTING\x10\x01\x12\x14\n\x10PIPELINE_RUNNING\x10\x02\x12\x17\n\x13PIPELINE_RESTARTING\x10\x03\x12\x14\n\x10PIPELINE_FAILURE\x10\x04\x12\x13\n\x0fPIPELINE_PAUSED\x10\x05\x12\x14\n\x10PIPELINE_STANDBY\x10\x06\x12\x15\n\x11PIPELINE_CRASHING\x10\x07*6\n\x12TolerationOperator\x12\t\n\x05\x45MPTY\x10\x00\x12\n\n\x06\x45XISTS\x10\x01\x12\t\n\x05\x45QUAL\x10\x02*W\n\x0bTaintEffect\x12\x0f\n\x0b\x41LL_EFFECTS\x10\x00\x12\x0f\n\x0bNO_SCHEDULE\x10\x01\x12\x16\n\x12PREFER_NO_SCHEDULE\x10\x02\x12\x0e\n\nNO_EXECUTE\x10\x03\x32\xde\x11\n\x03\x41PI\x12:\n\nInspectJob\x12\x19.pps_v2.InspectJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x12\x42\n\rInspectJobSet\x12\x1c.pps_v2.InspectJobSetRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12\x36\n\x07ListJob\x12\x16.pps_v2.ListJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12?\n\nListJobSet\x12\x19.pps_v2.ListJobSetRequest\x1a\x12.pps_v2.JobSetInfo\"\x00\x30\x01\x12@\n\x0cSubscribeJob\x12\x1b.pps_v2.SubscribeJobRequest\x1a\x0f.pps_v2.JobInfo\"\x00\x30\x01\x12?\n\tDeleteJob\x12\x18.pps_v2.DeleteJobRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\x07StopJob\x12\x16.pps_v2.StopJobRequest\x1a\x16.google.protobuf.Empty\"\x00\x12@\n\x0cInspectDatum\x12\x1b.pps_v2.InspectDatumRequest\x1a\x11.pps_v2.DatumInfo\"\x00\x12<\n\tListDatum\x12\x18.pps_v2.ListDatumRequest\x1a\x11.pps_v2.DatumInfo\"\x00\x30\x01\x12\x45\n\x0cRestartDatum\x12\x1b.pps_v2.RestartDatumRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n\x0e\x43reatePipeline\x12\x1d.pps_v2.CreatePipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n\x0fInspectPipeline\x12\x1e.pps_v2.InspectPipelineRequest\x1a\x14.pps_v2.PipelineInfo\"\x00\x12\x45\n\x0cListPipeline\x12\x1b.pps_v2.ListPipelineRequest\x1a\x14.pps_v2.PipelineInfo\"\x00\x30\x01\x12I\n\x0e\x44\x65letePipeline\x12\x1d.pps_v2.DeletePipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12T\n\x0f\x44\x65letePipelines\x12\x1e.pps_v2.DeletePipelinesRequest\x1a\x1f.pps_v2.DeletePipelinesResponse\"\x00\x12G\n\rStartPipeline\x12\x1c.pps_v2.StartPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0cStopPipeline\x12\x1b.pps_v2.StopPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x43\n\x0bRunPipeline\x12\x1a.pps_v2.RunPipelineRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\x07RunCron\x12\x16.pps_v2.RunCronRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0c\x43reateSecret\x12\x1b.pps_v2.CreateSecretRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x45\n\x0c\x44\x65leteSecret\x12\x1b.pps_v2.DeleteSecretRequest\x1a\x16.google.protobuf.Empty\"\x00\x12;\n\nListSecret\x12\x16.google.protobuf.Empty\x1a\x13.pps_v2.SecretInfos\"\x00\x12\x43\n\rInspectSecret\x12\x1c.pps_v2.InspectSecretRequest\x1a\x12.pps_v2.SecretInfo\"\x00\x12=\n\tDeleteAll\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12\x39\n\x07GetLogs\x12\x16.pps_v2.GetLogsRequest\x1a\x12.pps_v2.LogMessage\"\x00\x30\x01\x12K\n\x0c\x41\x63tivateAuth\x12\x1b.pps_v2.ActivateAuthRequest\x1a\x1c.pps_v2.ActivateAuthResponse\"\x00\x12I\n\x0eUpdateJobState\x12\x1d.pps_v2.UpdateJobStateRequest\x1a\x16.google.protobuf.Empty\"\x00\x12H\n\x0bRunLoadTest\x12\x1a.pps_v2.RunLoadTestRequest\x1a\x1b.pps_v2.RunLoadTestResponse\"\x00\x12K\n\x12RunLoadTestDefault\x12\x16.google.protobuf.Empty\x1a\x1b.pps_v2.RunLoadTestResponse\"\x00\x12Q\n\x0eRenderTemplate\x12\x1d.pps_v2.RenderTemplateRequest\x1a\x1e.pps_v2.RenderTemplateResponse\"\x00\x12;\n\x08ListTask\x12\x18.taskapi.ListTaskRequest\x1a\x11.taskapi.TaskInfo\"\x00\x30\x01\x12@\n\rGetKubeEvents\x12\x13.pps_v2.LokiRequest\x1a\x16.pps_v2.LokiLogMessage\"\x00\x30\x01\x12<\n\tQueryLoki\x12\x13.pps_v2.LokiRequest\x1a\x16.pps_v2.LokiLogMessage\"\x00\x30\x01\x42+Z)github.com/pachyderm/pachyderm/v2/src/ppsb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_protobuf_dot_duration__pb2.DESCRIPTOR,google_dot_protobuf_dot_wrappers__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2.DESCRIPTOR,python__pachyderm_dot_proto_dot_v2_dot_task_dot_task__pb2.DESCRIPTOR,])
 
@@ -90,8 +90,8 @@ _JOBSTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11366,
-  serialized_end=11559,
+  serialized_start=12055,
+  serialized_end=12248,
 )
 _sym_db.RegisterEnumDescriptor(_JOBSTATE)
 
@@ -136,8 +136,8 @@ _DATUMSTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11561,
-  serialized_end=11653,
+  serialized_start=12250,
+  serialized_end=12342,
 )
 _sym_db.RegisterEnumDescriptor(_DATUMSTATE)
 
@@ -172,8 +172,8 @@ _WORKERSTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11655,
-  serialized_end=11744,
+  serialized_start=12344,
+  serialized_end=12433,
 )
 _sym_db.RegisterEnumDescriptor(_WORKERSTATE)
 
@@ -228,8 +228,8 @@ _PIPELINESTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11747,
-  serialized_end=11948,
+  serialized_start=12436,
+  serialized_end=12637,
 )
 _sym_db.RegisterEnumDescriptor(_PIPELINESTATE)
 
@@ -259,8 +259,8 @@ _TOLERATIONOPERATOR = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=11950,
-  serialized_end=12004,
+  serialized_start=12639,
+  serialized_end=12693,
 )
 _sym_db.RegisterEnumDescriptor(_TOLERATIONOPERATOR)
 
@@ -295,8 +295,8 @@ _TAINTEFFECT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=12006,
-  serialized_end=12093,
+  serialized_start=12695,
+  serialized_end=12782,
 )
 _sym_db.RegisterEnumDescriptor(_TAINTEFFECT)
 
@@ -368,8 +368,8 @@ _PIPELINEINFO_PIPELINETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=6254,
-  serialized_end=6376,
+  serialized_start=6370,
+  serialized_end=6492,
 )
 _sym_db.RegisterEnumDescriptor(_PIPELINEINFO_PIPELINETYPE)
 
@@ -678,6 +678,38 @@ _EGRESS = _descriptor.Descriptor(
 )
 
 
+_DETERMINED = _descriptor.Descriptor(
+  name='Determined',
+  full_name='pps_v2.Determined',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='workspaces', full_name='pps_v2.Determined.workspaces', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=894,
+  serialized_end=926,
+)
+
+
 _JOB = _descriptor.Descriptor(
   name='Job',
   full_name='pps_v2.Job',
@@ -712,8 +744,8 @@ _JOB = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=894,
-  serialized_end=947,
+  serialized_start=928,
+  serialized_end=981,
 )
 
 
@@ -751,8 +783,8 @@ _METADATA_ANNOTATIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1064,
-  serialized_end=1114,
+  serialized_start=1098,
+  serialized_end=1148,
 )
 
 _METADATA_LABELSENTRY = _descriptor.Descriptor(
@@ -789,8 +821,8 @@ _METADATA_LABELSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1116,
-  serialized_end=1161,
+  serialized_start=1150,
+  serialized_end=1195,
 )
 
 _METADATA = _descriptor.Descriptor(
@@ -827,8 +859,8 @@ _METADATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=950,
-  serialized_end=1161,
+  serialized_start=984,
+  serialized_end=1195,
 )
 
 
@@ -880,8 +912,8 @@ _SERVICE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1163,
-  serialized_end=1244,
+  serialized_start=1197,
+  serialized_end=1278,
 )
 
 
@@ -912,8 +944,8 @@ _SPOUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1246,
-  serialized_end=1287,
+  serialized_start=1280,
+  serialized_end=1321,
 )
 
 
@@ -1035,8 +1067,8 @@ _PFSINPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1290,
-  serialized_end=1546,
+  serialized_start=1324,
+  serialized_end=1580,
 )
 
 
@@ -1109,8 +1141,8 @@ _CRONINPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1549,
-  serialized_end=1697,
+  serialized_start=1583,
+  serialized_end=1731,
 )
 
 
@@ -1176,8 +1208,8 @@ _INPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1700,
-  serialized_end=1890,
+  serialized_start=1734,
+  serialized_end=1924,
 )
 
 
@@ -1229,8 +1261,8 @@ _JOBINPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1892,
-  serialized_end=1976,
+  serialized_start=1926,
+  serialized_end=2010,
 )
 
 
@@ -1261,8 +1293,8 @@ _PARALLELISMSPEC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1978,
-  serialized_end=2013,
+  serialized_start=2012,
+  serialized_end=2047,
 )
 
 
@@ -1300,8 +1332,8 @@ _INPUTFILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2015,
-  serialized_end=2054,
+  serialized_start=2049,
+  serialized_end=2088,
 )
 
 
@@ -1339,8 +1371,8 @@ _DATUM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2056,
-  serialized_end=2101,
+  serialized_start=2090,
+  serialized_end=2135,
 )
 
 
@@ -1406,8 +1438,8 @@ _DATUMINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2104,
-  serialized_end=2300,
+  serialized_start=2138,
+  serialized_end=2334,
 )
 
 
@@ -1466,8 +1498,8 @@ _AGGREGATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2302,
-  serialized_end=2417,
+  serialized_start=2336,
+  serialized_end=2451,
 )
 
 
@@ -1526,8 +1558,8 @@ _PROCESSSTATS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2420,
-  serialized_end=2627,
+  serialized_start=2454,
+  serialized_end=2661,
 )
 
 
@@ -1586,8 +1618,8 @@ _AGGREGATEPROCESSSTATS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2630,
-  serialized_end=2860,
+  serialized_start=2664,
+  serialized_end=2894,
 )
 
 
@@ -1632,8 +1664,8 @@ _WORKERSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2862,
-  serialized_end=2954,
+  serialized_start=2896,
+  serialized_end=2988,
 )
 
 
@@ -1671,8 +1703,8 @@ _DATUMSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2956,
-  serialized_end=3047,
+  serialized_start=2990,
+  serialized_end=3081,
 )
 
 
@@ -1724,8 +1756,8 @@ _RESOURCESPEC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3049,
-  serialized_end=3136,
+  serialized_start=3083,
+  serialized_end=3170,
 )
 
 
@@ -1763,8 +1795,8 @@ _GPUSPEC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3138,
-  serialized_end=3177,
+  serialized_start=3172,
+  serialized_end=3211,
 )
 
 
@@ -1802,8 +1834,8 @@ _JOBSETINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3179,
-  serialized_end=3255,
+  serialized_start=3213,
+  serialized_end=3289,
 )
 
 
@@ -1960,8 +1992,8 @@ _JOBINFO_DETAILS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3753,
-  serialized_end=4495,
+  serialized_start=3807,
+  serialized_end=4549,
 )
 
 _JOBINFO = _descriptor.Descriptor(
@@ -2084,6 +2116,13 @@ _JOBINFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='auth_token', full_name='pps_v2.JobInfo.auth_token', index=16,
+      number=17, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -2096,8 +2135,8 @@ _JOBINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3258,
-  serialized_end=4495,
+  serialized_start=3292,
+  serialized_end=4549,
 )
 
 
@@ -2135,8 +2174,8 @@ _WORKER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4497,
-  serialized_end=4555,
+  serialized_start=4551,
+  serialized_end=4609,
 )
 
 
@@ -2174,8 +2213,8 @@ _PIPELINE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4557,
-  serialized_end=4615,
+  serialized_start=4611,
+  serialized_end=4669,
 )
 
 
@@ -2234,8 +2273,8 @@ _TOLERATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4618,
-  serialized_end=4798,
+  serialized_start=4672,
+  serialized_end=4852,
 )
 
 
@@ -2478,6 +2517,13 @@ _PIPELINEINFO_DETAILS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='determined', full_name='pps_v2.PipelineInfo.Details.determined', index=33,
+      number=36, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -2490,8 +2536,8 @@ _PIPELINEINFO_DETAILS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5158,
-  serialized_end=6252,
+  serialized_start=5234,
+  serialized_end=6368,
 )
 
 _PIPELINEINFO = _descriptor.Descriptor(
@@ -2579,6 +2625,13 @@ _PIPELINEINFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='details_json', full_name='pps_v2.PipelineInfo.details_json', index=11,
+      number=13, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -2592,8 +2645,8 @@ _PIPELINEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4801,
-  serialized_end=6382,
+  serialized_start=4855,
+  serialized_end=6498,
 )
 
 
@@ -2624,8 +2677,8 @@ _PIPELINEINFOS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6384,
-  serialized_end=6444,
+  serialized_start=6500,
+  serialized_end=6560,
 )
 
 
@@ -2656,8 +2709,8 @@ _JOBSET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6446,
-  serialized_end=6466,
+  serialized_start=6562,
+  serialized_end=6582,
 )
 
 
@@ -2702,8 +2755,8 @@ _INSPECTJOBSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6468,
-  serialized_end=6554,
+  serialized_start=6584,
+  serialized_end=6670,
 )
 
 
@@ -2750,6 +2803,13 @@ _LISTJOBSETREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='jqFilter', full_name='pps_v2.ListJobSetRequest.jqFilter', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -2762,8 +2822,8 @@ _LISTJOBSETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6557,
-  serialized_end=6715,
+  serialized_start=6673,
+  serialized_end=6849,
 )
 
 
@@ -2808,8 +2868,8 @@ _INSPECTJOBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6717,
-  serialized_end=6793,
+  serialized_start=6851,
+  serialized_end=6927,
 )
 
 
@@ -2896,8 +2956,8 @@ _LISTJOBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6796,
-  serialized_end=7060,
+  serialized_start=6930,
+  serialized_end=7194,
 )
 
 
@@ -2935,8 +2995,8 @@ _SUBSCRIBEJOBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7062,
-  serialized_end=7136,
+  serialized_start=7196,
+  serialized_end=7270,
 )
 
 
@@ -2967,8 +3027,8 @@ _DELETEJOBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7138,
-  serialized_end=7182,
+  serialized_start=7272,
+  serialized_end=7316,
 )
 
 
@@ -3006,8 +3066,8 @@ _STOPJOBREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7184,
-  serialized_end=7242,
+  serialized_start=7318,
+  serialized_end=7376,
 )
 
 
@@ -3101,8 +3161,8 @@ _UPDATEJOBSTATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7245,
-  serialized_end=7508,
+  serialized_start=7379,
+  serialized_end=7642,
 )
 
 
@@ -3189,8 +3249,8 @@ _GETLOGSREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7511,
-  serialized_end=7755,
+  serialized_start=7645,
+  serialized_end=7889,
 )
 
 
@@ -3284,8 +3344,8 @@ _LOGMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7758,
-  serialized_end=7988,
+  serialized_start=7892,
+  serialized_end=8122,
 )
 
 
@@ -3323,8 +3383,8 @@ _RESTARTDATUMREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7990,
-  serialized_end=8059,
+  serialized_start=8124,
+  serialized_end=8193,
 )
 
 
@@ -3355,8 +3415,8 @@ _INSPECTDATUMREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8061,
-  serialized_end=8112,
+  serialized_start=8195,
+  serialized_end=8246,
 )
 
 
@@ -3387,8 +3447,8 @@ _LISTDATUMREQUEST_FILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8299,
-  serialized_end=8342,
+  serialized_start=8433,
+  serialized_end=8476,
 )
 
 _LISTDATUMREQUEST = _descriptor.Descriptor(
@@ -3453,8 +3513,8 @@ _LISTDATUMREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8115,
-  serialized_end=8342,
+  serialized_start=8249,
+  serialized_end=8476,
 )
 
 
@@ -3499,8 +3559,8 @@ _DATUMSETSPEC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8344,
-  serialized_end=8414,
+  serialized_start=8478,
+  serialized_end=8548,
 )
 
 
@@ -3538,8 +3598,8 @@ _SCHEDULINGSPEC_NODESELECTORENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8529,
-  serialized_end=8580,
+  serialized_start=8663,
+  serialized_end=8714,
 )
 
 _SCHEDULINGSPEC = _descriptor.Descriptor(
@@ -3576,8 +3636,8 @@ _SCHEDULINGSPEC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8417,
-  serialized_end=8580,
+  serialized_start=8551,
+  serialized_end=8714,
 )
 
 
@@ -3799,6 +3859,27 @@ _CREATEPIPELINEREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='details_json', full_name='pps_v2.CreatePipelineRequest.details_json', index=30,
+      number=36, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dry_run', full_name='pps_v2.CreatePipelineRequest.dry_run', index=31,
+      number=37, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='determined', full_name='pps_v2.CreatePipelineRequest.determined', index=32,
+      number=38, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -3811,8 +3892,40 @@ _CREATEPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8583,
-  serialized_end=9615,
+  serialized_start=8717,
+  serialized_end=9828,
+)
+
+
+_CREATEPIPELINERESPONSE = _descriptor.Descriptor(
+  name='CreatePipelineResponse',
+  full_name='pps_v2.CreatePipelineResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='details_json', full_name='pps_v2.CreatePipelineResponse.details_json', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=9830,
+  serialized_end=9876,
 )
 
 
@@ -3850,8 +3963,8 @@ _INSPECTPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9617,
-  serialized_end=9694,
+  serialized_start=9878,
+  serialized_end=9955,
 )
 
 
@@ -3917,8 +4030,8 @@ _LISTPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9697,
-  serialized_end=9880,
+  serialized_start=9958,
+  serialized_end=10141,
 )
 
 
@@ -3970,8 +4083,8 @@ _DELETEPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9882,
-  serialized_end=9992,
+  serialized_start=10143,
+  serialized_end=10253,
 )
 
 
@@ -4023,8 +4136,8 @@ _DELETEPIPELINESREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=9994,
-  serialized_end=10100,
+  serialized_start=10255,
+  serialized_end=10361,
 )
 
 
@@ -4055,8 +4168,8 @@ _DELETEPIPELINESRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10102,
-  serialized_end=10164,
+  serialized_start=10363,
+  serialized_end=10425,
 )
 
 
@@ -4087,8 +4200,8 @@ _STARTPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10166,
-  serialized_end=10224,
+  serialized_start=10427,
+  serialized_end=10485,
 )
 
 
@@ -4119,8 +4232,8 @@ _STOPPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10226,
-  serialized_end=10283,
+  serialized_start=10487,
+  serialized_end=10544,
 )
 
 
@@ -4165,8 +4278,8 @@ _RUNPIPELINEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10285,
-  serialized_end=10393,
+  serialized_start=10546,
+  serialized_end=10654,
 )
 
 
@@ -4197,8 +4310,8 @@ _RUNCRONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10395,
-  serialized_end=10447,
+  serialized_start=10656,
+  serialized_end=10708,
 )
 
 
@@ -4229,8 +4342,8 @@ _CREATESECRETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10449,
-  serialized_end=10484,
+  serialized_start=10710,
+  serialized_end=10745,
 )
 
 
@@ -4261,8 +4374,8 @@ _DELETESECRETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10486,
-  serialized_end=10539,
+  serialized_start=10747,
+  serialized_end=10800,
 )
 
 
@@ -4293,8 +4406,8 @@ _INSPECTSECRETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10541,
-  serialized_end=10595,
+  serialized_start=10802,
+  serialized_end=10856,
 )
 
 
@@ -4325,8 +4438,8 @@ _SECRET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10597,
-  serialized_end=10619,
+  serialized_start=10858,
+  serialized_end=10880,
 )
 
 
@@ -4371,8 +4484,8 @@ _SECRETINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10621,
-  serialized_end=10735,
+  serialized_start=10882,
+  serialized_end=10996,
 )
 
 
@@ -4403,8 +4516,8 @@ _SECRETINFOS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10737,
-  serialized_end=10791,
+  serialized_start=10998,
+  serialized_end=11052,
 )
 
 
@@ -4428,8 +4541,8 @@ _ACTIVATEAUTHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10793,
-  serialized_end=10814,
+  serialized_start=11054,
+  serialized_end=11075,
 )
 
 
@@ -4453,8 +4566,8 @@ _ACTIVATEAUTHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10816,
-  serialized_end=10838,
+  serialized_start=11077,
+  serialized_end=11099,
 )
 
 
@@ -4520,8 +4633,8 @@ _RUNLOADTESTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10841,
-  serialized_end=10970,
+  serialized_start=11102,
+  serialized_end=11231,
 )
 
 
@@ -4559,8 +4672,8 @@ _RUNLOADTESTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=10972,
-  serialized_end=11026,
+  serialized_start=11233,
+  serialized_end=11287,
 )
 
 
@@ -4598,8 +4711,8 @@ _RENDERTEMPLATEREQUEST_ARGSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11127,
-  serialized_end=11170,
+  serialized_start=11388,
+  serialized_end=11431,
 )
 
 _RENDERTEMPLATEREQUEST = _descriptor.Descriptor(
@@ -4636,8 +4749,8 @@ _RENDERTEMPLATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11029,
-  serialized_end=11170,
+  serialized_start=11290,
+  serialized_end=11431,
 )
 
 
@@ -4675,8 +4788,8 @@ _RENDERTEMPLATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11172,
-  serialized_end=11256,
+  serialized_start=11433,
+  serialized_end=11517,
 )
 
 
@@ -4714,8 +4827,8 @@ _LOKIREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11258,
-  serialized_end=11328,
+  serialized_start=11519,
+  serialized_end=11589,
 )
 
 
@@ -4746,8 +4859,196 @@ _LOKILOGMESSAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=11330,
-  serialized_end=11363,
+  serialized_start=11591,
+  serialized_end=11624,
+)
+
+
+_CLUSTERDEFAULTS = _descriptor.Descriptor(
+  name='ClusterDefaults',
+  full_name='pps_v2.ClusterDefaults',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='details_json', full_name='pps_v2.ClusterDefaults.details_json', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='effective_details_json', full_name='pps_v2.ClusterDefaults.effective_details_json', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11626,
+  serialized_end=11697,
+)
+
+
+_GETCLUSTERDEFAULTSREQUEST = _descriptor.Descriptor(
+  name='GetClusterDefaultsRequest',
+  full_name='pps_v2.GetClusterDefaultsRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11699,
+  serialized_end=11726,
+)
+
+
+_GETCLUSTERDEFAULTSRESPONSE = _descriptor.Descriptor(
+  name='GetClusterDefaultsResponse',
+  full_name='pps_v2.GetClusterDefaultsResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='cluster_defaults', full_name='pps_v2.GetClusterDefaultsResponse.cluster_defaults', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11728,
+  serialized_end=11807,
+)
+
+
+_SETCLUSTERDEFAULTSREQUEST = _descriptor.Descriptor(
+  name='SetClusterDefaultsRequest',
+  full_name='pps_v2.SetClusterDefaultsRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='cluster_defaults', full_name='pps_v2.SetClusterDefaultsRequest.cluster_defaults', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='regenerate', full_name='pps_v2.SetClusterDefaultsRequest.regenerate', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='reprocess', full_name='pps_v2.SetClusterDefaultsRequest.reprocess', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='dry_run', full_name='pps_v2.SetClusterDefaultsRequest.dry_run', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11810,
+  serialized_end=11944,
+)
+
+
+_SETCLUSTERDEFAULTSRESPONSE = _descriptor.Descriptor(
+  name='SetClusterDefaultsResponse',
+  full_name='pps_v2.SetClusterDefaultsResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='effective_details_json', full_name='pps_v2.SetClusterDefaultsResponse.effective_details_json', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='affected_pipelines', full_name='pps_v2.SetClusterDefaultsResponse.affected_pipelines', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=11946,
+  serialized_end=12052,
 )
 
 _TRANSFORM_ENVENTRY.containing_type = _TRANSFORM
@@ -4843,6 +5144,7 @@ _PIPELINEINFO_DETAILS.fields_by_name['scheduling_spec'].message_type = _SCHEDULI
 _PIPELINEINFO_DETAILS.fields_by_name['metadata'].message_type = _METADATA
 _PIPELINEINFO_DETAILS.fields_by_name['tolerations'].message_type = _TOLERATION
 _PIPELINEINFO_DETAILS.fields_by_name['sidecar_resource_requests'].message_type = _RESOURCESPEC
+_PIPELINEINFO_DETAILS.fields_by_name['determined'].message_type = _DETERMINED
 _PIPELINEINFO_DETAILS.containing_type = _PIPELINEINFO
 _PIPELINEINFO.fields_by_name['pipeline'].message_type = _PIPELINE
 _PIPELINEINFO.fields_by_name['spec_commit'].message_type = python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2._COMMIT
@@ -4900,6 +5202,7 @@ _CREATEPIPELINEREQUEST.fields_by_name['spec_commit'].message_type = python__pach
 _CREATEPIPELINEREQUEST.fields_by_name['metadata'].message_type = _METADATA
 _CREATEPIPELINEREQUEST.fields_by_name['tolerations'].message_type = _TOLERATION
 _CREATEPIPELINEREQUEST.fields_by_name['sidecar_resource_requests'].message_type = _RESOURCESPEC
+_CREATEPIPELINEREQUEST.fields_by_name['determined'].message_type = _DETERMINED
 _INSPECTPIPELINEREQUEST.fields_by_name['pipeline'].message_type = _PIPELINE
 _LISTPIPELINEREQUEST.fields_by_name['pipeline'].message_type = _PIPELINE
 _LISTPIPELINEREQUEST.fields_by_name['commit_set'].message_type = python__pachyderm_dot_proto_dot_v2_dot_pfs_dot_pfs__pb2._COMMITSET
@@ -4921,10 +5224,14 @@ _RENDERTEMPLATEREQUEST_ARGSENTRY.containing_type = _RENDERTEMPLATEREQUEST
 _RENDERTEMPLATEREQUEST.fields_by_name['args'].message_type = _RENDERTEMPLATEREQUEST_ARGSENTRY
 _RENDERTEMPLATERESPONSE.fields_by_name['specs'].message_type = _CREATEPIPELINEREQUEST
 _LOKIREQUEST.fields_by_name['since'].message_type = google_dot_protobuf_dot_duration__pb2._DURATION
+_GETCLUSTERDEFAULTSRESPONSE.fields_by_name['cluster_defaults'].message_type = _CLUSTERDEFAULTS
+_SETCLUSTERDEFAULTSREQUEST.fields_by_name['cluster_defaults'].message_type = _CLUSTERDEFAULTS
+_SETCLUSTERDEFAULTSRESPONSE.fields_by_name['affected_pipelines'].message_type = _PIPELINE
 DESCRIPTOR.message_types_by_name['SecretMount'] = _SECRETMOUNT
 DESCRIPTOR.message_types_by_name['Transform'] = _TRANSFORM
 DESCRIPTOR.message_types_by_name['TFJob'] = _TFJOB
 DESCRIPTOR.message_types_by_name['Egress'] = _EGRESS
+DESCRIPTOR.message_types_by_name['Determined'] = _DETERMINED
 DESCRIPTOR.message_types_by_name['Job'] = _JOB
 DESCRIPTOR.message_types_by_name['Metadata'] = _METADATA
 DESCRIPTOR.message_types_by_name['Service'] = _SERVICE
@@ -4968,6 +5275,7 @@ DESCRIPTOR.message_types_by_name['ListDatumRequest'] = _LISTDATUMREQUEST
 DESCRIPTOR.message_types_by_name['DatumSetSpec'] = _DATUMSETSPEC
 DESCRIPTOR.message_types_by_name['SchedulingSpec'] = _SCHEDULINGSPEC
 DESCRIPTOR.message_types_by_name['CreatePipelineRequest'] = _CREATEPIPELINEREQUEST
+DESCRIPTOR.message_types_by_name['CreatePipelineResponse'] = _CREATEPIPELINERESPONSE
 DESCRIPTOR.message_types_by_name['InspectPipelineRequest'] = _INSPECTPIPELINEREQUEST
 DESCRIPTOR.message_types_by_name['ListPipelineRequest'] = _LISTPIPELINEREQUEST
 DESCRIPTOR.message_types_by_name['DeletePipelineRequest'] = _DELETEPIPELINEREQUEST
@@ -4991,6 +5299,11 @@ DESCRIPTOR.message_types_by_name['RenderTemplateRequest'] = _RENDERTEMPLATEREQUE
 DESCRIPTOR.message_types_by_name['RenderTemplateResponse'] = _RENDERTEMPLATERESPONSE
 DESCRIPTOR.message_types_by_name['LokiRequest'] = _LOKIREQUEST
 DESCRIPTOR.message_types_by_name['LokiLogMessage'] = _LOKILOGMESSAGE
+DESCRIPTOR.message_types_by_name['ClusterDefaults'] = _CLUSTERDEFAULTS
+DESCRIPTOR.message_types_by_name['GetClusterDefaultsRequest'] = _GETCLUSTERDEFAULTSREQUEST
+DESCRIPTOR.message_types_by_name['GetClusterDefaultsResponse'] = _GETCLUSTERDEFAULTSRESPONSE
+DESCRIPTOR.message_types_by_name['SetClusterDefaultsRequest'] = _SETCLUSTERDEFAULTSREQUEST
+DESCRIPTOR.message_types_by_name['SetClusterDefaultsResponse'] = _SETCLUSTERDEFAULTSRESPONSE
 DESCRIPTOR.enum_types_by_name['JobState'] = _JOBSTATE
 DESCRIPTOR.enum_types_by_name['DatumState'] = _DATUMSTATE
 DESCRIPTOR.enum_types_by_name['WorkerState'] = _WORKERSTATE
@@ -5034,6 +5347,13 @@ Egress = _reflection.GeneratedProtocolMessageType('Egress', (_message.Message,),
   # @@protoc_insertion_point(class_scope:pps_v2.Egress)
   })
 _sym_db.RegisterMessage(Egress)
+
+Determined = _reflection.GeneratedProtocolMessageType('Determined', (_message.Message,), {
+  'DESCRIPTOR' : _DETERMINED,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.Determined)
+  })
+_sym_db.RegisterMessage(Determined)
 
 Job = _reflection.GeneratedProtocolMessageType('Job', (_message.Message,), {
   'DESCRIPTOR' : _JOB,
@@ -5384,6 +5704,13 @@ CreatePipelineRequest = _reflection.GeneratedProtocolMessageType('CreatePipeline
   })
 _sym_db.RegisterMessage(CreatePipelineRequest)
 
+CreatePipelineResponse = _reflection.GeneratedProtocolMessageType('CreatePipelineResponse', (_message.Message,), {
+  'DESCRIPTOR' : _CREATEPIPELINERESPONSE,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.CreatePipelineResponse)
+  })
+_sym_db.RegisterMessage(CreatePipelineResponse)
+
 InspectPipelineRequest = _reflection.GeneratedProtocolMessageType('InspectPipelineRequest', (_message.Message,), {
   'DESCRIPTOR' : _INSPECTPIPELINEREQUEST,
   '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
@@ -5553,6 +5880,41 @@ LokiLogMessage = _reflection.GeneratedProtocolMessageType('LokiLogMessage', (_me
   })
 _sym_db.RegisterMessage(LokiLogMessage)
 
+ClusterDefaults = _reflection.GeneratedProtocolMessageType('ClusterDefaults', (_message.Message,), {
+  'DESCRIPTOR' : _CLUSTERDEFAULTS,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.ClusterDefaults)
+  })
+_sym_db.RegisterMessage(ClusterDefaults)
+
+GetClusterDefaultsRequest = _reflection.GeneratedProtocolMessageType('GetClusterDefaultsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETCLUSTERDEFAULTSREQUEST,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.GetClusterDefaultsRequest)
+  })
+_sym_db.RegisterMessage(GetClusterDefaultsRequest)
+
+GetClusterDefaultsResponse = _reflection.GeneratedProtocolMessageType('GetClusterDefaultsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETCLUSTERDEFAULTSRESPONSE,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.GetClusterDefaultsResponse)
+  })
+_sym_db.RegisterMessage(GetClusterDefaultsResponse)
+
+SetClusterDefaultsRequest = _reflection.GeneratedProtocolMessageType('SetClusterDefaultsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _SETCLUSTERDEFAULTSREQUEST,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.SetClusterDefaultsRequest)
+  })
+_sym_db.RegisterMessage(SetClusterDefaultsRequest)
+
+SetClusterDefaultsResponse = _reflection.GeneratedProtocolMessageType('SetClusterDefaultsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _SETCLUSTERDEFAULTSRESPONSE,
+  '__module__' : 'python_pachyderm.proto.v2.pps.pps_pb2'
+  # @@protoc_insertion_point(class_scope:pps_v2.SetClusterDefaultsResponse)
+  })
+_sym_db.RegisterMessage(SetClusterDefaultsResponse)
+
 
 DESCRIPTOR._options = None
 _TRANSFORM_ENVENTRY._options = None
@@ -5569,8 +5931,8 @@ _API = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=12096,
-  serialized_end=14366,
+  serialized_start=12785,
+  serialized_end=15055,
   methods=[
   _descriptor.MethodDescriptor(
     name='InspectJob',

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -6,11 +6,11 @@ import python_pachyderm
 from google.protobuf import duration_pb2
 
 
-def test_dump():
+def test_dump_v2():
     client = python_pachyderm.Client()
-    for b in client.dump():
-        assert isinstance(b, bytes)
-        assert len(b) > 0
+    response = next(client.dump_v2())
+    assert isinstance(response.content.content, bytes)
+    assert response.progress.progress > 0
 
 
 def test_profile_cpu():

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -8,7 +8,7 @@ from google.protobuf import duration_pb2
 
 def test_dump_v2():
     client = python_pachyderm.Client()
-    response = next(client.dump_v2())
+    response = next(client.dump())
     assert isinstance(response.content.content, bytes)
     assert response.progress.progress > 0
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "pachyderm": "2.6.0",
+    "pachyderm": "2.7.0",
     "kubernetes": "1.22.8",
     "minikube": "1.30.1"
 }


### PR DESCRIPTION
The main change is moving to the `/Debug/DumpV2` api. Additionally the `details_json` field for /Pps/CreatePipeline` was reserved in the protos but support has not yet been implemented